### PR TITLE
Add flexible http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+- Add a flexible http client providing both contract, and only emulating what's necessary
+
+
 ## 1.0.0 - 2016-01-27
 
 ### Changed

--- a/spec/HttpClientFlexibleSpec.php
+++ b/spec/HttpClientFlexibleSpec.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace spec\Http\Client\Common;
+
+use Http\Client\Common\HttpAsyncClientDecorator;
+use Http\Client\Common\HttpClientDecorator;
+use Http\Client\Common\HttpClientFlexible;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Prophet;
+
+class HttpClientFlexibleSpec extends ObjectBehavior
+{
+    function let(HttpClient $httpClient)
+    {
+        $this->beAnInstanceOf(
+            'spec\Http\Client\Common\HttpClientFlexibleStub', [
+                $httpClient
+            ]
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Client\Common\HttpClientFlexible');
+    }
+
+    function it_is_an_http_client()
+    {
+        $this->shouldImplement('Http\Client\HttpClient');
+    }
+
+    function it_is_an_async_http_client()
+    {
+        $this->shouldImplement('Http\Client\HttpAsyncClient');
+    }
+
+    function it_throw_exception_if_invalid_client()
+    {
+        $httpClient = null;
+        $this->beConstructedWith($httpClient);
+
+        $this->shouldThrow('\LogicException')->duringInstantiation();
+    }
+
+    function it_emulates_an_async_client(HttpClient $httpClient)
+    {
+        $this->beConstructedWith($httpClient);
+
+        $this->getClient()->shouldImplement('Http\Client\HttpClient');
+        $this->getAsyncClient()->shouldImplement('Http\Client\HttpAsyncClient');
+        $this->getClient()->shouldNotImplement('Http\Client\Common\EmulatedHttpClient');
+        $this->getAsyncClient()->shouldImplement('Http\Client\Common\EmulatedHttpAsyncClient');
+    }
+
+    function it_emulates_a_client(HttpAsyncClient $httpAsyncClient)
+    {
+        $this->beConstructedWith($httpAsyncClient);
+
+        $this->getClient()->shouldImplement('Http\Client\HttpClient');
+        $this->getAsyncClient()->shouldImplement('Http\Client\HttpAsyncClient');
+        $this->getClient()->shouldImplement('Http\Client\Common\EmulatedHttpClient');
+        $this->getAsyncClient()->shouldNotImplement('Http\Client\EmulatedHttpAsyncClient');
+    }
+
+    function it_does_not_emulates_a_client()
+    {
+        $prophet = new Prophet();
+        $httpClient = $prophet->prophesize();
+        $httpClient->willImplement('Http\Client\HttpClient');
+        $httpClient->willImplement('Http\Client\HttpAsyncClient');
+
+        $this->beConstructedWith($httpClient);
+
+        $this->getClient()->shouldNotImplement('Http\Client\Common\EmulatedHttpClient');
+        $this->getAsyncClient()->shouldNotImplement('Http\Client\Common\EmulatedHttpAsyncClient');
+    }
+}
+
+class HttpClientFlexibleStub extends HttpClientFlexible
+{
+    public function getClient()
+    {
+        return $this->httpClient;
+    }
+
+    public function getAsyncClient()
+    {
+        return $this->httpAsyncClient;
+    }
+}

--- a/src/HttpClientFlexible.php
+++ b/src/HttpClientFlexible.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Http\Client\Common;
+
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+
+/**
+ * A flexible http client, which implements both interface and will emulate
+ * one contract, the other, or none at all depending on the injected client contract.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+class HttpClientFlexible implements HttpClient, HttpAsyncClient
+{
+    use HttpClientDecorator;
+    use HttpAsyncClientDecorator;
+
+    /**
+     * @param HttpClient|HttpAsyncClient $client
+     */
+    public function __construct($client)
+    {
+        if (!($client instanceof HttpClient) && !($client instanceof HttpAsyncClient)) {
+            throw new \LogicException('Client must be an instance of Http\\Client\\HttpClient or Http\\Client\\HttpAsyncClient');
+        }
+
+        $this->httpClient = $client;
+        $this->httpAsyncClient = $client;
+
+        if (!($this->httpClient instanceof HttpClient)) {
+            $this->httpClient = new EmulatedHttpClient($this->httpClient);
+        }
+
+        if (!($this->httpAsyncClient instanceof HttpAsyncClient)) {
+            $this->httpAsyncClient = new EmulatedHttpAsyncClient($this->httpAsyncClient);
+        }
+    }
+}


### PR DESCRIPTION
A flexible http client implements both interface and can emulate one of the contract if not present in the injected http client.