### PR TITLE
Added possibility for debug plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 - Suggest separate plugins in composer.json
+- Introduced `debug_plugins` option for `PluginClient`
 
 
 ## 1.1.0 - 2016-05-04

--- a/spec/PluginClientSpec.php
+++ b/spec/PluginClientSpec.php
@@ -87,4 +87,46 @@ class PluginClientSpec extends ObjectBehavior
 
         $this->shouldThrow('Http\Client\Common\Exception\LoopException')->duringSendRequest($request);
     }
+
+    function it_injects_debug_plugins(HttpClient $httpClient, RequestInterface $request, Plugin $plugin0, Plugin $plugin1, Plugin $debugPlugin)
+    {
+        $plugin0
+            ->handleRequest(
+                $request,
+                Argument::type('callable'),
+                Argument::type('callable')
+            )
+            ->shouldBeCalledTimes(1)
+            ->will(function ($args) {
+                return $args[1]($args[0]);
+            })
+        ;
+        $plugin1
+            ->handleRequest(
+                $request,
+                Argument::type('callable'),
+                Argument::type('callable')
+            )
+            ->shouldBeCalledTimes(1)
+            ->will(function ($args) {
+                return $args[1]($args[0]);
+            })
+        ;
+
+        $debugPlugin
+            ->handleRequest(
+                $request,
+                Argument::type('callable'),
+                Argument::type('callable')
+            )
+            ->shouldBeCalledTimes(3)
+            ->will(function ($args) {
+                return $args[1]($args[0]);
+            })
+        ;
+
+
+        $this->beConstructedWith($httpClient, [$plugin0, $plugin1], ['debug_plugins'=>[$debugPlugin]]);
+        $this->sendRequest($request);
+    }
 }

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -44,7 +44,8 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      * @param Plugin[]                   $plugins
      * @param array                      $options {
      *
-     *     @var int $max_restarts
+     *     @var int      $max_restarts
+     *     @var Plugin[] $debug_plugins an array of plugins that are injected between all normal plugins
      * }
      *
      * @throws \RuntimeException if client is not an instance of HttpClient or HttpAsyncClient
@@ -131,13 +132,13 @@ final class PluginClient implements HttpClient, HttpAsyncClient
         /*
          * Inject debug plugins between each plugin.
          */
-        $pluginListWithDegug = $this->options['debug_plugins'];
+        $pluginListWithDebug = $this->options['debug_plugins'];
         foreach ($pluginList as $plugin) {
-            $pluginListWithDegug[] = $plugin;
-            $pluginListWithDegug = array_merge($pluginListWithDegug, $this->options['debug_plugins']);
+            $pluginListWithDebug[] = $plugin;
+            $pluginListWithDebug = array_merge($pluginListWithDebug, $this->options['debug_plugins']);
         }
 
-        while ($plugin = array_pop($pluginListWithDegug)) {
+        while ($plugin = array_pop($pluginListWithDebug)) {
             $lastCallable = function (RequestInterface $request) use ($plugin, $lastCallable, &$firstCallable) {
                 return $plugin->handleRequest($request, $lastCallable, $firstCallable);
             };

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -110,7 +110,7 @@ final class PluginClient implements HttpClient, HttpAsyncClient
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'max_restarts' => 10,
-            'debug_plugins' => []
+            'debug_plugins' => [],
         ]);
 
         return $resolver->resolve($options);
@@ -129,7 +129,7 @@ final class PluginClient implements HttpClient, HttpAsyncClient
         $firstCallable = $lastCallable = $clientCallable;
 
         /*
-         * Inject debug plugins between each plugin.  
+         * Inject debug plugins between each plugin.
          */
         $pluginListWithDegug = $this->options['debug_plugins'];
         foreach ($pluginList as $plugin) {

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -45,7 +45,7 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      * @param array                      $options {
      *
      *     @var int      $max_restarts
-     *     @var Plugin[] $debug_plugins an array of plugins that are injected between all normal plugins
+     *     @var Plugin[] $debug_plugins an array of plugins that are injected between each normal plugin
      * }
      *
      * @throws \RuntimeException if client is not an instance of HttpClient or HttpAsyncClient

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -114,6 +114,19 @@ final class PluginClient implements HttpClient, HttpAsyncClient
             'debug_plugins' => [],
         ]);
 
+        $resolver
+            ->setAllowedTypes('debug_plugins', 'array')
+            ->setAllowedValues('debug_plugins', function (array $plugins) {
+                foreach ($plugins as $plugin) {
+                    // Make sure each object passed with the `debug_plugins` is an instance of Plugin.
+                    if (!$plugin instanceof Plugin) {
+                        return false;
+                    }
+                }
+
+                return true;
+            });
+
         return $resolver->resolve($options);
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/php-http/HttplugBundle/issues/26
| Documentation   | https://github.com/php-http/documentation/pull/109
| License         | MIT


#### What's in this PR?

This PR gives the possibility to add debug plugins. A debug plugin is executed between each normal plugin


#### Why?

With this PR we can show better diffs and how different plugins are changing the requests/responses.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)

