### PR TITLE
Add method to get last request sent

### DIFF
--- a/spec/HttpMethodsClientSpec.php
+++ b/spec/HttpMethodsClientSpec.php
@@ -85,6 +85,16 @@ class HttpMethodsClientSpec extends ObjectBehavior
         $this->beConstructedWith($client, $messageFactory);
         $this->sendRequest($request)->shouldReturn($response);
     }
+
+    function it_returns_last_request(HttpClient $client, MessageFactory $messageFactory, RequestInterface $request, ResponseInterface $response)
+    {
+        $client->sendRequest($request)->shouldBeCalled()->willReturn($response);
+
+        $this->beConstructedWith($client, $messageFactory);
+        $this->getLastRequest()->shouldReturn(null);
+        $this->sendRequest($request)->shouldReturn($response);
+        $this->getLastRequest()->shouldReturn($request);
+    }
 }
 
 class HttpMethodsClientStub extends HttpMethodsClient

--- a/src/HttpMethodsClient.php
+++ b/src/HttpMethodsClient.php
@@ -37,6 +37,11 @@ class HttpMethodsClient implements HttpClient
     private $messageFactory;
 
     /**
+     * @var RequestInterface
+     */
+    private $lastRequest;
+
+    /**
      * @param HttpClient     $httpClient     The client to send requests with.
      * @param MessageFactory $messageFactory The message factory to create requests.
      */
@@ -200,6 +205,20 @@ class HttpMethodsClient implements HttpClient
      */
     public function sendRequest(RequestInterface $request)
     {
+        $this->lastRequest = $request;
+
         return $this->httpClient->sendRequest($request);
+    }
+
+    /**
+     * Get the last request that was sent via this client.
+     *
+     * Note that this will not return requests made directly through the underlying client's sendRequest method.
+     *
+     * @return RequestInterface|null
+     */
+    public function getLastRequest()
+    {
+        return $this->lastRequest;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation TODO
| License         | MIT


#### What's in this PR?

Adds a method to get the last request that was sent.


#### Why?

When using HttpMethodsClient to send requests, you do not generally create the request object itself. The method added here provides you with a way to access the request that was created when using methods such as get, post, patch etc. This can be useful for instance if you wish to look at the request that was sent for debugging or logging purposes.

Please let me know if you think there is a better way of achieving this, or if this is already possible.

#### Example Usage

``` php
use Http\Discovery\HttpClientDiscovery;
use Http\Discovery\MessageFactoryDiscovery

$client = new HttpMethodsClient(
    HttpClientDiscovery::find(),
    MessageFactoryDiscovery::find()
);

$foo = $client->get('http://example.com/foo');
$request = $client->getLastRequest(); // contains a GET request to http://example.com/foo
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

Nothing

