### PR TITLE
adjust phpdoc of error plugin

### DIFF
--- a/src/Plugin/ErrorPlugin.php
+++ b/src/Plugin/ErrorPlugin.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Throw exception when the response of a request is not acceptable.
  *
- * By default an exception will be thrown for all status codes from 400 to 599.
+ * Status codes 400-499 lead to a ClientErrorException, status 500-599 to a ServerErrorException.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Phpdoc adjust.


#### Why?

The doc said "by default" but there is no options to change behaviour.