### PR TITLE
AddHostPlugin must also handle the port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Changed
+
+- AddHostPlugin also sets the port if specified
 
 ## 1.2.0 - 2016-07-14
 

--- a/spec/Plugin/AddHostPluginSpec.php
+++ b/spec/Plugin/AddHostPluginSpec.php
@@ -39,12 +39,14 @@ class AddHostPluginSpec extends ObjectBehavior
     ) {
         $host->getScheme()->shouldBeCalled()->willReturn('http://');
         $host->getHost()->shouldBeCalled()->willReturn('example.com');
+        $host->getPort()->shouldBeCalled()->willReturn(8000);
 
         $request->getUri()->shouldBeCalled()->willReturn($uri);
         $request->withUri($uri)->shouldBeCalled()->willReturn($request);
 
         $uri->withScheme('http://')->shouldBeCalled()->willReturn($uri);
         $uri->withHost('example.com')->shouldBeCalled()->willReturn($uri);
+        $uri->withPort(8000)->shouldBeCalled()->willReturn($uri);
         $uri->getHost()->shouldBeCalled()->willReturn('');
 
         $this->beConstructedWith($host);
@@ -58,13 +60,14 @@ class AddHostPluginSpec extends ObjectBehavior
     ) {
         $host->getScheme()->shouldBeCalled()->willReturn('http://');
         $host->getHost()->shouldBeCalled()->willReturn('example.com');
+        $host->getPort()->shouldBeCalled()->willReturn(8000);
 
         $request->getUri()->shouldBeCalled()->willReturn($uri);
         $request->withUri($uri)->shouldBeCalled()->willReturn($request);
 
         $uri->withScheme('http://')->shouldBeCalled()->willReturn($uri);
         $uri->withHost('example.com')->shouldBeCalled()->willReturn($uri);
-
+        $uri->withPort(8000)->shouldBeCalled()->willReturn($uri);
 
         $this->beConstructedWith($host, ['replace' => true]);
         $this->handleRequest($request, function () {}, function () {});

--- a/src/Plugin/AddHostPlugin.php
+++ b/src/Plugin/AddHostPlugin.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\UriInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Add schema and host to a request. Can be set to overwrite the schema and host if desired.
+ * Add schema, host and port to a request. Can be set to overwrite the schema and host if desired.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
@@ -52,8 +52,11 @@ final class AddHostPlugin implements Plugin
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
         if ($this->replace || $request->getUri()->getHost() === '') {
-            $uri = $request->getUri()->withHost($this->host->getHost());
-            $uri = $uri->withScheme($this->host->getScheme());
+            $uri = $request->getUri()
+                ->withHost($this->host->getHost())
+                ->withScheme($this->host->getScheme())
+                ->withPort($this->host->getPort())
+            ;
 
             $request = $request->withUri($uri);
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | only if you relied on the bug
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

The AddHostPlugin did not look at the port and thus the port was either the default or in the case of overriding an existing host the port specified in the request.


#### Why?

It makes more sense to overwrite the port along with the domain and protocol.


#### Example Usage

``` php
$uriFactory = new \Http\Message\UriFactory\GuzzleUriFactory();
new AddHostPlugin($uriFactory->createUri('http://localhost:8000'));
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix): https://github.com/php-http/documentation/issues/121 there is no doc atm.
