### PR TITLE
Added PluginClientBuilder

### DIFF
--- a/src/PluginClientBuilder.php
+++ b/src/PluginClientBuilder.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Http\Client\Common;
+
+use Http\Client\HttpClient;
+
+/**
+ * A builder that help you build a PluginClient.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class PluginClientBuilder implements PluginClientBuilderInterface
+{
+    /**
+     * @var Plugin[]
+     */
+    protected $plugins = [];
+
+    /**
+     * @var bool
+     */
+    protected $rebuildClient = true;
+
+    /**
+     * The last created client with the plugins
+     *
+     * @var PluginClient
+     */
+    private $pluginClient;
+
+    /**
+     * The object that sends HTTP messages
+     *
+     * @var HttpClient
+     */
+    private $httpClient;
+
+    /**
+     *
+     * @param HttpClient $httpClient
+     */
+    public function __construct(HttpClient $httpClient = null)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * Add a new plugin to the end of the plugin chain.
+     *
+     * @param Plugin $plugin
+     */
+    public function addPlugin(Plugin $plugin)
+    {
+        $this->plugins[] = $plugin;
+        $this->rebuildClient = true;
+    }
+
+    /**
+     * Remove a plugin by its fully qualified class name (FQCN).
+     *
+     * @param string $fqcn
+     */
+    public function removePlugin($fqcn)
+    {
+        foreach ($this->plugins as $idx => $plugin) {
+            if ($plugin instanceof $fqcn) {
+                unset($this->plugins[$idx]);
+                $this->rebuildClient = true;
+            }
+        }
+    }
+
+    /**
+     * Alias for removePlugin and addPlugin
+     *
+     * @param Plugin $plugin
+     */
+    public function replacePlugin(Plugin $plugin)
+    {
+        $this->removePlugin(get_class($plugin));
+        $this->addPlugin($plugin);
+    }
+
+    /**
+     * Get all plugins
+     *
+     * @return Plugin[]
+     */
+    public function getPlugins()
+    {
+        return $this->plugins;
+    }
+
+    /**
+     * This will overwrite all existing plugins
+     *
+     * @param Plugin[] $plugins
+     *
+     * @return PluginClientBuilder
+     */
+    public function setPlugins($plugins)
+    {
+        $this->plugins = $plugins;
+        $this->rebuildClient = true;
+    }
+
+    /**
+     * @return PluginClient
+     */
+    public function buildClient()
+    {
+        if (!$this->httpClient) {
+            throw new \RuntimeException('No HTTP client were provided to the PluginBuilder.');
+        }
+
+        if ($this->rebuildClient) {
+            $this->rebuildClient = false;
+            $this->pushBackCachePlugin();
+
+            $this->pluginClient = new PluginClient($this->httpClient, $this->plugins);
+        }
+
+        return $this->pluginClient;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isModified()
+    {
+        return $this->rebuildClient;
+    }
+
+    /**
+     * @param HttpClient $httpClient
+     */
+    public function setHttpClient(HttpClient $httpClient)
+    {
+        $this->rebuildClient = true;
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @return HttpClient
+     */
+    public function getHttpClient()
+    {
+        return $this->httpClient;
+    }
+
+    /**
+     * Make sure to move the cache plugin to the end of the chain
+     */
+    private function pushBackCachePlugin()
+    {
+        $cachePlugin = null;
+        foreach ($this->plugins as $i => $plugin) {
+            if ($plugin instanceof Plugin\CachePlugin) {
+                $cachePlugin = $plugin;
+                unset($this->plugins[$i]);
+
+                $this->plugins[] = $cachePlugin;
+
+                return;
+            }
+        }
+    }
+}

--- a/src/PluginClientBuilderInterface.php
+++ b/src/PluginClientBuilderInterface.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Http\Client\Common;
+
+use Http\Client\HttpClient;
+
+/**
+ * A builder that help you build a PluginClient.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface PluginClientBuilderInterface
+{
+    /**
+     * Add a new plugin to the end of the plugin chain.
+     *
+     * @param Plugin $plugin
+     */
+    public function addPlugin(Plugin $plugin);
+
+    /**
+     * Remove a plugin by its fully qualified class name (FQCN).
+     *
+     * @param string $fqcn
+     */
+    public function removePlugin($fqcn);
+
+    /**
+     * Alias for removePlugin and addPlugin.
+     *
+     * @param Plugin $plugin
+     */
+    public function replacePlugin(Plugin $plugin);
+
+    /**
+     * Get all plugins.
+     *
+     * @return Plugin[]
+     */
+    public function getPlugins();
+
+    /**
+     * This will overwrite all existing plugins.
+     *
+     * @param Plugin[] $plugins
+     *
+     * @return PluginClientBuilder
+     */
+    public function setPlugins($plugins);
+
+    /**
+     * @return PluginClient
+     */
+    public function buildClient();
+
+    /**
+     * @param HttpClient $httpClient
+     */
+    public function setHttpClient(HttpClient $httpClient);
+
+    /**
+     * @return HttpClient
+     */
+    public function getHttpClient();
+
+    /**
+     * @return bool
+     */
+    public function isModified();
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Related tickets | related to https://github.com/php-http/HttplugBundle/issues/109 |
| Documentation |  |
| License | MIT |
#### What's in this PR?

This is a plugin builder that could be use to build up a Plugin client. See example usage: https://github.com/Nyholm/php-github-api/blob/plugin-client-builder/lib/Github/Client.php
#### Why?
- If a library builds up the PluginClient manually there is no way for us (HTTPlugBundle) to know what plugins that are used and we cannot show any plugin stack in the web profiler
- We could "risk" having multiple plugin chains which will cause issues when using the cache plugin if a later plugin is rewriting the url. (or any other part of the cache key)
- A pluginClientBuilder will make it easy for the LibraryBundle to integrate the library with Symfony and HTTPlugBundle. 
#### Checklist
- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
#### To Do
- [ ] Clean the code
- [ ] Figure out if the interface is needed
- [ ] Figure out the final interface

This PR needs some work but I wanted to share this code
