### PR TITLE
Add AddPathPlugin and BaseUriPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Require Httplug 1.1 where we use HTTP specific promises. 
 - RedirectPlugin: use the full URL instead of the URI to properly keep track of redirects
 - Add AddPathPlugin for API URLs with base path
+- Add BaseUriPlugin that combines AddHostPlugin and AddPathPlugin
 
 ## 1.2.1 - 2016-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fix Emulated Trait to use Http based promise which respect the HttpAsyncClient interface
 - Require Httplug 1.1 where we use HTTP specific promises. 
 - RedirectPlugin: use the full URL instead of the URI to properly keep track of redirects
-
+- Add AddPathPlugin for API URLs with base path
 
 ## 1.2.1 - 2016-07-26
 

--- a/spec/Plugin/AddPathPluginSpec.php
+++ b/spec/Plugin/AddPathPluginSpec.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace spec\Http\Client\Common\Plugin;
+
+use Http\Message\StreamFactory;
+use Http\Message\UriFactory;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use PhpSpec\ObjectBehavior;
+
+class AddPathPluginSpec extends ObjectBehavior
+{
+    function let(UriInterface $uri)
+    {
+        $this->beConstructedWith($uri);
+    }
+
+    function it_is_initializable(UriInterface $uri)
+    {
+        $uri->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $this->shouldHaveType('Http\Client\Common\Plugin\AddPathPlugin');
+    }
+
+    function it_is_a_plugin(UriInterface $uri)
+    {
+        $uri->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $this->shouldImplement('Http\Client\Common\Plugin');
+    }
+
+    function it_adds_path(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $host->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldBeCalled()->willReturn($request);
+
+        $uri->withPath('/api/users')->shouldBeCalled()->willReturn($uri);
+        $uri->getPath()->shouldBeCalled()->willReturn('/users');
+
+        $this->beConstructedWith($host);
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_throws_exception_on_trailing_slash(UriInterface $host)
+    {
+        $host->getPath()->shouldBeCalled()->willReturn('/api/');
+
+        $this->beConstructedWith($host);
+        $this->shouldThrow('\LogicException')->duringInstantiation();
+    }
+
+    function it_throws_exception_on_empty_path(UriInterface $host)
+    {
+        $host->getPath()->shouldBeCalled()->willReturn('');
+
+        $this->beConstructedWith($host);
+        $this->shouldThrow('\LogicException')->duringInstantiation();
+    }
+}

--- a/spec/Plugin/BaseUriPluginSpec.php
+++ b/spec/Plugin/BaseUriPluginSpec.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace spec\Http\Client\Common\Plugin;
+
+use Http\Message\StreamFactory;
+use Http\Message\UriFactory;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use PhpSpec\ObjectBehavior;
+
+class BaseUriPluginSpec extends ObjectBehavior
+{
+    function let(UriInterface $uri)
+    {
+        $this->beConstructedWith($uri);
+    }
+
+    function it_is_initializable(UriInterface $uri)
+    {
+        $uri->getHost()->shouldBeCalled()->willReturn('example.com');
+        $uri->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $this->shouldHaveType('Http\Client\Common\Plugin\BaseUriPlugin');
+    }
+
+    function it_is_a_plugin(UriInterface $uri)
+    {
+        $uri->getHost()->shouldBeCalled()->willReturn('example.com');
+        $uri->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $this->shouldImplement('Http\Client\Common\Plugin');
+    }
+
+    function it_adds_domain_and_path(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $host->getScheme()->shouldBeCalled()->willReturn('http://');
+        $host->getHost()->shouldBeCalled()->willReturn('example.com');
+        $host->getPort()->shouldBeCalled()->willReturn(8000);
+        $host->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldBeCalled()->willReturn($request);
+
+        $uri->withScheme('http://')->shouldBeCalled()->willReturn($uri);
+        $uri->withHost('example.com')->shouldBeCalled()->willReturn($uri);
+        $uri->withPort(8000)->shouldBeCalled()->willReturn($uri);
+        $uri->withPath('/api/users')->shouldBeCalled()->willReturn($uri);
+        $uri->getHost()->shouldBeCalled()->willReturn('');
+        $uri->getPath()->shouldBeCalled()->willReturn('/users');
+
+        $this->beConstructedWith($host);
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_adds_domain(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $host->getScheme()->shouldBeCalled()->willReturn('http://');
+        $host->getHost()->shouldBeCalled()->willReturn('example.com');
+        $host->getPort()->shouldBeCalled()->willReturn(8000);
+        $host->getPath()->shouldBeCalled()->willReturn('/');
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldBeCalled()->willReturn($request);
+
+        $uri->withScheme('http://')->shouldBeCalled()->willReturn($uri);
+        $uri->withHost('example.com')->shouldBeCalled()->willReturn($uri);
+        $uri->withPort(8000)->shouldBeCalled()->willReturn($uri);
+        $uri->getHost()->shouldBeCalled()->willReturn('');
+
+        $this->beConstructedWith($host);
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_replaces_domain_and_adds_path(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $host->getScheme()->shouldBeCalled()->willReturn('http://');
+        $host->getHost()->shouldBeCalled()->willReturn('example.com');
+        $host->getPort()->shouldBeCalled()->willReturn(8000);
+        $host->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldBeCalled()->willReturn($request);
+
+        $uri->withScheme('http://')->shouldBeCalled()->willReturn($uri);
+        $uri->withHost('example.com')->shouldBeCalled()->willReturn($uri);
+        $uri->withPort(8000)->shouldBeCalled()->willReturn($uri);
+        $uri->withPath('/api/users')->shouldBeCalled()->willReturn($uri);
+        $uri->getPath()->shouldBeCalled()->willReturn('/users');
+
+        $this->beConstructedWith($host, ['replace' => true]);
+        $this->handleRequest($request, function () {}, function () {});
+    }
+}

--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Http\Client\Common\Plugin;
+
+use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Prepend a base path to the request URI. Useful for base API URLs like http://domain.com/api.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class AddPathPlugin implements Plugin
+{
+    /**
+     * @var UriInterface
+     */
+    private $uri;
+
+    /**
+     * @param UriInterface $uri
+     */
+    public function __construct(UriInterface $uri)
+    {
+        if ($uri->getPath() === '') {
+            throw new \LogicException('URI path cannot be empty');
+        }
+
+        if (substr($uri->getPath(), -1) === '/') {
+            throw new \LogicException('URI path cannot end with a slash.');
+        }
+
+        $this->uri = $uri;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        $request = $request->withUri($request->getUri()
+            ->withPath($this->uri->getPath().$request->getUri()->getPath())
+        );
+
+        return $next($request);
+    }
+}

--- a/src/Plugin/BaseUriPlugin.php
+++ b/src/Plugin/BaseUriPlugin.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Http\Client\Common\Plugin;
+
+use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Combines the AddHostPlugin and AddPathPlugin.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class BaseUriPlugin implements Plugin
+{
+    /**
+     * @var AddHostPlugin
+     */
+    private $addHostPlugin;
+
+    /**
+     * @var AddPathPlugin|null
+     */
+    private $addPathPlugin = null;
+
+    /**
+     * @param UriInterface $uri        Has to contain a host name and cans have a path.
+     * @param array        $hostConfig Config for AddHostPlugin. @see AddHostPlugin::configureOptions
+     */
+    public function __construct(UriInterface $uri, array $hostConfig = [])
+    {
+        $this->addHostPlugin = new AddHostPlugin($uri, $hostConfig);
+
+        if (rtrim($uri->getPath(), '/')) {
+            $this->addPathPlugin = new AddPathPlugin($uri);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        $addHostNext = function (RequestInterface $request) use ($next, $first) {
+            return $this->addHostPlugin->handleRequest($request, $next, $first);
+        };
+
+        if ($this->addPathPlugin) {
+            return $this->addPathPlugin->handleRequest($request, $addHostNext, $first);
+        }
+
+        return $addHostNext($request);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no since this is a kind of bug regarding the situation
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | https://github.com/php-http/documentation/pull/163
| License         | MIT

#### What's in this PR?

This bugfix permits to keep the base path of an URI on the `AddHost` plugin.

#### Why?

With the following PHP code example:

```php
$httpClient = new HttpMethodsClient(
    new PluginClient(HttpClientDiscovery::find(), [
        new AddHostPlugin(UriFactoryDiscovery::find()->createUri('https://logs.domain.com/api')),
        new ErrorPlugin(),
    ]),
    MessageFactoryDiscovery::find()
);
$httpClient->get('/users');
```

The https://logs.domain.com/users URL will be called instead of /api/users.

The base path should be kept on this plugin.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Update the tests