### PR TITLE
Fix deflate encoding handling and disable compress encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Unreleased
+
+### Deprecated
+
+- `DecoderPlugin` does not longer claim to support `compress` content encoding
+
+### Fixed
+
+- `DecoderPlugin` uses the right `FilteredStream` to handle `deflate` content encoding
+
 ## 1.4.1 - 2017-02-20
 
 ### Fixed

--- a/spec/Plugin/DecoderPluginSpec.php
+++ b/spec/Plugin/DecoderPluginSpec.php
@@ -28,8 +28,8 @@ class DecoderPluginSpec extends ObjectBehavior
             throw new SkippingException('Skipping test on hhvm, as there is no chunk encoding on hhvm');
         }
 
-        $request->withHeader('TE', ['gzip', 'deflate', 'compress', 'chunked'])->shouldBeCalled()->willReturn($request);
-        $request->withHeader('Accept-Encoding', ['gzip', 'deflate', 'compress'])->shouldBeCalled()->willReturn($request);
+        $request->withHeader('TE', ['gzip', 'deflate', 'chunked'])->shouldBeCalled()->willReturn($request);
+        $request->withHeader('Accept-Encoding', ['gzip', 'deflate'])->shouldBeCalled()->willReturn($request);
         $next = function () use($response) {
             return new HttpFulfilledPromise($response->getWrappedObject());
         };
@@ -50,8 +50,8 @@ class DecoderPluginSpec extends ObjectBehavior
 
     function it_decodes_gzip(RequestInterface $request, ResponseInterface $response, StreamInterface $stream)
     {
-        $request->withHeader('TE', ['gzip', 'deflate', 'compress', 'chunked'])->shouldBeCalled()->willReturn($request);
-        $request->withHeader('Accept-Encoding', ['gzip', 'deflate', 'compress'])->shouldBeCalled()->willReturn($request);
+        $request->withHeader('TE', ['gzip', 'deflate', 'chunked'])->shouldBeCalled()->willReturn($request);
+        $request->withHeader('Accept-Encoding', ['gzip', 'deflate'])->shouldBeCalled()->willReturn($request);
         $next = function () use($response) {
             return new HttpFulfilledPromise($response->getWrappedObject());
         };
@@ -72,8 +72,8 @@ class DecoderPluginSpec extends ObjectBehavior
 
     function it_decodes_deflate(RequestInterface $request, ResponseInterface $response, StreamInterface $stream)
     {
-        $request->withHeader('TE', ['gzip', 'deflate', 'compress', 'chunked'])->shouldBeCalled()->willReturn($request);
-        $request->withHeader('Accept-Encoding', ['gzip', 'deflate', 'compress'])->shouldBeCalled()->willReturn($request);
+        $request->withHeader('TE', ['gzip', 'deflate', 'chunked'])->shouldBeCalled()->willReturn($request);
+        $request->withHeader('Accept-Encoding', ['gzip', 'deflate'])->shouldBeCalled()->willReturn($request);
         $next = function () use($response) {
             return new HttpFulfilledPromise($response->getWrappedObject());
         };
@@ -81,28 +81,6 @@ class DecoderPluginSpec extends ObjectBehavior
         $response->hasHeader('Transfer-Encoding')->willReturn(false);
         $response->hasHeader('Content-Encoding')->willReturn(true);
         $response->getHeader('Content-Encoding')->willReturn(['deflate']);
-        $response->getBody()->willReturn($stream);
-        $response->withBody(Argument::type('Http\Message\Encoding\InflateStream'))->willReturn($response);
-        $response->withHeader('Content-Encoding', [])->willReturn($response);
-
-        $stream->isReadable()->willReturn(true);
-        $stream->isWritable()->willReturn(false);
-        $stream->eof()->willReturn(false);
-
-        $this->handleRequest($request, $next, function () {});
-    }
-
-    function it_decodes_inflate(RequestInterface $request, ResponseInterface $response, StreamInterface $stream)
-    {
-        $request->withHeader('TE', ['gzip', 'deflate', 'compress', 'chunked'])->shouldBeCalled()->willReturn($request);
-        $request->withHeader('Accept-Encoding', ['gzip', 'deflate', 'compress'])->shouldBeCalled()->willReturn($request);
-        $next = function () use($response) {
-            return new HttpFulfilledPromise($response->getWrappedObject());
-        };
-
-        $response->hasHeader('Transfer-Encoding')->willReturn(false);
-        $response->hasHeader('Content-Encoding')->willReturn(true);
-        $response->getHeader('Content-Encoding')->willReturn(['compress']);
         $response->getBody()->willReturn($stream);
         $response->withBody(Argument::type('Http\Message\Encoding\DecompressStream'))->willReturn($response);
         $response->withHeader('Content-Encoding', [])->willReturn($response);
@@ -118,8 +96,8 @@ class DecoderPluginSpec extends ObjectBehavior
     {
         $this->beConstructedWith(['use_content_encoding' => false]);
 
-        $request->withHeader('TE', ['gzip', 'deflate', 'compress', 'chunked'])->shouldBeCalled()->willReturn($request);
-        $request->withHeader('Accept-Encoding', ['gzip', 'deflate', 'compress'])->shouldNotBeCalled();
+        $request->withHeader('TE', ['gzip', 'deflate', 'chunked'])->shouldBeCalled()->willReturn($request);
+        $request->withHeader('Accept-Encoding', ['gzip', 'deflate'])->shouldNotBeCalled();
         $next = function () use($response) {
             return new HttpFulfilledPromise($response->getWrappedObject());
         };

--- a/src/Plugin/DecoderPlugin.php
+++ b/src/Plugin/DecoderPlugin.php
@@ -50,7 +50,7 @@ final class DecoderPlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
-        $encodings = extension_loaded('zlib') ? ['gzip', 'deflate', 'compress'] : ['identity'];
+        $encodings = extension_loaded('zlib') ? ['gzip', 'deflate'] : ['identity'];
 
         if ($this->useContentEncoding) {
             $request = $request->withHeader('Accept-Encoding', $encodings);
@@ -127,12 +127,8 @@ final class DecoderPlugin implements Plugin
             return new Encoding\DechunkStream($stream);
         }
 
-        if (strtolower($encoding) == 'compress') {
-            return new Encoding\DecompressStream($stream);
-        }
-
         if (strtolower($encoding) == 'deflate') {
-            return new Encoding\InflateStream($stream);
+            return new Encoding\DecompressStream($stream);
         }
 
         if (strtolower($encoding) == 'gzip') {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no/yes
| Deprecations?   | no/yes
| License         | MIT


#### What's in this PR?

This PR updates the DecoderPlugin to use the right decoder to manage deflate content-encoding and disable compress as there is no support in PHP and nobody uses it

This is the solution proposed by @joelwurtz in https://github.com/php-http/message/issues/64#issuecomment-255958592 to the problem is described in https://github.com/php-http/message/issues/64

#### Example Usage

``` php
<?php
require 'vendor/autoload.php';

$decoderPlugin = new Http\Client\Common\Plugin\DecoderPlugin();
$pluginClient = new Http\Client\Common\PluginClient(
    Http\Discovery\HttpClientDiscovery::find(),
    [$decoderPlugin]
);

$response = $pluginClient->sendRequest(
    new GuzzleHttp\Psr7\Request('GET', 'http://httpbin.org/deflate')
);

var_dump($response->getBody()->getContents());

```

The result should be a JSON document like the one you can view at http://httpbin.org/deflate, but it returns a response with an empty body.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

