### PR TITLE
Cross subdomain cookie sharing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- `CookiePlugin` allows main domain cookies to be sent/stored for subdomains
 - `DecoderPlugin` uses the right `FilteredStream` to handle `deflate` content encoding
 
 ## 1.4.1 - 2017-02-20

--- a/spec/Plugin/CookiePluginSpec.php
+++ b/spec/Plugin/CookiePluginSpec.php
@@ -84,19 +84,25 @@ class CookiePluginSpec extends ObjectBehavior
 
     function it_does_not_load_cookie_on_hackish_domains(RequestInterface $request, UriInterface $uri, Promise $promise)
     {
+        $hackishDomains = [
+            'hacktest.com',
+            'test.com.hacked.org',
+        ];
         $cookie = new Cookie('name', 'value', 86400, 'test.com');
         $this->cookieJar->addCookie($cookie);
 
-        $request->getUri()->willReturn($uri);
-        $uri->getHost()->willReturn('hacktest.com');
+        foreach ($hackishDomains as $domain) {
+            $request->getUri()->willReturn($uri);
+            $uri->getHost()->willReturn($domain);
 
-        $request->withAddedHeader('Cookie', 'name=value')->shouldNotBeCalled();
+            $request->withAddedHeader('Cookie', 'name=value')->shouldNotBeCalled();
 
-        $this->handleRequest($request, function (RequestInterface $requestReceived) use ($request, $promise) {
-            if (Argument::is($requestReceived)->scoreArgument($request->getWrappedObject())) {
-                return $promise->getWrappedObject();
-            }
-        }, function () {});
+            $this->handleRequest($request, function (RequestInterface $requestReceived) use ($request, $promise) {
+                if (Argument::is($requestReceived)->scoreArgument($request->getWrappedObject())) {
+                    return $promise->getWrappedObject();
+                }
+            }, function () {});
+        }
     }
 
     function it_loads_cookie_on_subdomains(RequestInterface $request, UriInterface $uri, Promise $promise)

--- a/src/Plugin/CookiePlugin.php
+++ b/src/Plugin/CookiePlugin.php
@@ -69,7 +69,7 @@ final class CookiePlugin implements Plugin
                     }
 
                     // Restrict setting cookie from another domain
-                    if (false === strpos($cookie->getDomain(), $request->getUri()->getHost())) {
+                    if (false === strpos($request->getUri()->getHost(), $cookie->getDomain())) {
                         continue;
                     }
 

--- a/src/Plugin/CookiePlugin.php
+++ b/src/Plugin/CookiePlugin.php
@@ -69,7 +69,11 @@ final class CookiePlugin implements Plugin
                     }
 
                     // Restrict setting cookie from another domain
-                    if (false === strpos($request->getUri()->getHost(), $cookie->getDomain())) {
+                    if (false === strpos(
+                            '.'.$request->getUri()->getHost(),
+                            '.'.$cookie->getDomain()
+                        )
+                    ) {
                         continue;
                     }
 

--- a/src/Plugin/CookiePlugin.php
+++ b/src/Plugin/CookiePlugin.php
@@ -69,11 +69,7 @@ final class CookiePlugin implements Plugin
                     }
 
                     // Restrict setting cookie from another domain
-                    if (false === strpos(
-                            '.'.$request->getUri()->getHost(),
-                            '.'.$cookie->getDomain()
-                        )
-                    ) {
+                    if (!preg_match("/\.{$cookie->getDomain()}$/", '.'.$request->getUri()->getHost())) {
                         continue;
                     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #62
| License         | MIT


#### What's in this PR?

The changes make cookies set for main domain available for subdomains as well, as described in [RFC 6265](https://tools.ietf.org/html/rfc6265#section-5.2.3)


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)