### PR TITLE
deprecate debug_plugin options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
 
+## Unreleased
+
+### Deprecated
+
+- The `debug_plugins` option for `PluginClient` is deprecated and will be removed in 2.0. Use the decorator design pattern instead like in [ProfilePlugin](https://github.com/php-http/HttplugBundle/blob/de33f9c14252f22093a5ec7d84f17535ab31a384/Collector/ProfilePlugin.php).
+
 ## 1.4.2 - 2017-03-18
 
 ### Deprecated

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -108,6 +108,10 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      */
     private function configure(array $options = [])
     {
+        if (isset($options['debug_plugins'])) {
+            @trigger_error('The "debug_plugins" option is deprecated since 1.5 and will be removed in 2.0.', E_USER_DEPRECATED);
+        }
+
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'max_restarts' => 10,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #60 
| Documentation   | N/A
| License         | MIT

#### What's in this PR?

The `PluginClient` now triggers a deprecation notice when the `debug_plugins` option is set.


#### Why?

The `debug_plugins` option was used by the HttplugBundle collector, but since https://github.com/php-http/HttplugBundle/pull/128 is merged, it's no longer required.
