### PR TITLE
add plugin client factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `PluginClientFactory` to create `PluginClient` instances.
+
 ### Deprecated
 
 - The `debug_plugins` option for `PluginClient` is deprecated and will be removed in 2.0. Use the decorator design pattern instead like in [ProfilePlugin](https://github.com/php-http/HttplugBundle/blob/de33f9c14252f22093a5ec7d84f17535ab31a384/Collector/ProfilePlugin.php).

--- a/spec/PluginClientFactorySpec.php
+++ b/spec/PluginClientFactorySpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\Http\Client\Common;
+
+use Http\Client\HttpClient;
+use PhpSpec\ObjectBehavior;
+
+class PluginClientFactorySpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Client\Common\PluginClientFactory');
+    }
+
+    function it_returns_a_plugin_client(HttpClient $httpClient)
+    {
+        $client = $this->createClient($httpClient);
+
+        $client->shouldHaveType('Http\Client\Common\PluginClient');
+    }
+}

--- a/src/PluginClientFactory.php
+++ b/src/PluginClientFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Http\Client\Common;
+
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+
+/**
+ * @author Fabien Bourigault <bourigaultfabien@gmail.com>
+ */
+final class PluginClientFactory
+{
+    /**
+     * @var callable
+     */
+    private static $factory;
+
+    /**
+     * Set the factory to use.
+     * The callable to provide must have the same arguments and return type as PluginClientFactory::createClient.
+     * This is used by the HTTPlugBundle to provide a better Symfony integration.
+     *
+     * @internal
+     *
+     * @param callable $factory
+     */
+    public static function setFactory(callable $factory)
+    {
+        static::$factory = $factory;
+    }
+
+    /**
+     * @param HttpClient|HttpAsyncClient $client
+     * @param Plugin[]                   $plugins
+     * @param array                      $options {
+     *
+     *     @var string $client_name to give client a name which may be used when displaying client information  like in
+     *         the HTTPlugBundle profiler.
+     * }
+     *
+     * @see PluginClient constructor for PluginClient specific $options.
+     *
+     * @return PluginClient
+     */
+    public function createClient($client, array $plugins = [], array $options = [])
+    {
+        if (static::$factory) {
+            $factory = static::$factory;
+
+            return $factory($client, $plugins, $options);
+        }
+
+        return new PluginClient($client, $plugins, $options);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially https://github.com/php-http/HttplugBundle/issues/109
| Documentation   | TODO
| License         | MIT

This is required to display plugins created by 3rd party libraries in the HttplugBundle profiler. See https://github.com/php-http/HttplugBundle/issues/109#issuecomment-300461535 for all puzzle pieces.

#### To Do

- [x] Update the changelog.
- [ ] Update the documentation.