### PR TITLE
Add AddPathPlugin always_prepend option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Add the `always_prepend` option to `AddPathPlugin`.
+- The `BaseUriPlugin` can now passthru options for the underlying `AddPathPlugin`.
+
 ### Deprecated
 
 - The `debug_plugins` option for `PluginClient` is deprecated and will be removed in 2.0. Use the decorator design pattern instead like in [ProfilePlugin](https://github.com/php-http/HttplugBundle/blob/de33f9c14252f22093a5ec7d84f17535ab31a384/Collector/ProfilePlugin.php).

--- a/spec/Plugin/AddPathPluginSpec.php
+++ b/spec/Plugin/AddPathPluginSpec.php
@@ -61,4 +61,23 @@ class AddPathPluginSpec extends ObjectBehavior
         $this->beConstructedWith($host);
         $this->shouldThrow('\LogicException')->duringInstantiation();
     }
+
+    function it_adds_path_only_if_required(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $host->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldNotBeCalled();
+
+        $uri->withPath('/api/api/users')->shouldNotBeCalled();
+        $uri->getPath()->shouldBeCalled()->willReturn('/api/users');
+
+        $this->beConstructedWith($host, [
+            'always_prepend' => false,
+        ]);
+        $this->handleRequest($request, function () {}, function () {});
+    }
 }

--- a/spec/Plugin/BaseUriPluginSpec.php
+++ b/spec/Plugin/BaseUriPluginSpec.php
@@ -99,4 +99,22 @@ class BaseUriPluginSpec extends ObjectBehavior
         $this->beConstructedWith($host, ['replace' => true]);
         $this->handleRequest($request, function () {}, function () {});
     }
+
+    function it_adds_path_only_if_required(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $uri
+    ) {
+        $host->getHost()->shouldBeCalled()->willReturn('example.com');
+        $host->getPath()->shouldBeCalled()->willReturn('/api');
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldNotBeCalled();
+
+        $uri->getHost()->shouldBeCalled()->willReturn('example.com');
+        $uri->getPath()->shouldBeCalled()->willReturn('/api/users');
+
+        $this->beConstructedWith($host, [], ['always_prepend' => false]);
+        $this->handleRequest($request, function () {}, function () {});
+    }
 }

--- a/src/Plugin/BaseUriPlugin.php
+++ b/src/Plugin/BaseUriPlugin.php
@@ -26,13 +26,14 @@ final class BaseUriPlugin implements Plugin
     /**
      * @param UriInterface $uri        Has to contain a host name and cans have a path.
      * @param array        $hostConfig Config for AddHostPlugin. @see AddHostPlugin::configureOptions
+     * @param array        $pathConfig Config for AddPassPlugin. @see AddPathPlugin::configureOptions
      */
-    public function __construct(UriInterface $uri, array $hostConfig = [])
+    public function __construct(UriInterface $uri, array $hostConfig = [], array $pathConfig = [])
     {
         $this->addHostPlugin = new AddHostPlugin($uri, $hostConfig);
 
         if (rtrim($uri->getPath(), '/')) {
-            $this->addPathPlugin = new AddPathPlugin($uri);
+            $this->addPathPlugin = new AddPathPlugin($uri, $pathConfig);
         }
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | TODO
| License         | MIT

This allow to make the `AddPathPlugin` smart. By smart I mean to not prepend the configured URI path to the request URI if already present. This behavior is disabled by default to keep code BC.

The `BaseUriPlugin` now has a third optional constructor argument to configure the underlying `AddPathPlugin`.

This is required for https://github.com/m4tthumphrey/php-gitlab-api which has a base URI set to `https://example.gitlab.com/api/v3` but is also used to follow pagination `Link` headers uri which already have the base URI configured.

## To do
* [ ] Documentation.
* [x] Changelog.