### PR TITLE
Use trusty dist for travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 cache:
     directories:
         - $HOME/.composer/cache/files


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT

This is about fixing travis-ci HHVM build. See https://travis-ci.org/php-http/client-common/jobs/240025931.