### PR TITLE
Supports more cookie date formats in the Cookie Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `PluginClientFactory` to create `PluginClient` instances.
 - Added new option 'delay' for `RetryPlugin`.
 - Added new option 'decider' for `RetryPlugin`.
+- Supports more cookie date formats in the Cookie Plugin
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.4",
         "php-http/httplug": "^1.1",
         "php-http/message-factory": "^1.0",
-        "php-http/message": "^1.2",
+        "php-http/message": "^1.6",
         "symfony/options-resolver": "^2.6 || ^3.0"
     },
     "require-dev": {

--- a/src/Plugin/CookiePlugin.php
+++ b/src/Plugin/CookiePlugin.php
@@ -6,6 +6,8 @@ use Http\Client\Common\Plugin;
 use Http\Client\Exception\TransferException;
 use Http\Message\Cookie;
 use Http\Message\CookieJar;
+use Http\Message\CookieUtil;
+use Http\Message\Exception\UnexpectedValueException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -114,15 +116,17 @@ final class CookiePlugin implements Plugin
 
             switch (strtolower($key)) {
                 case 'expires':
-                    $expires = \DateTime::createFromFormat(\DateTime::COOKIE, $value);
-
-                    if (true !== ($expires instanceof \DateTime)) {
+                    try {
+                        $expires = CookieUtil::parseDate($value);
+                    } catch (UnexpectedValueException $e) {
                         throw new TransferException(
                             sprintf(
                                 'Cookie header `%s` expires value `%s` could not be converted to date',
                                 $name,
                                 $value
-                            )
+                            ),
+                            null,
+                            $e
                         );
                     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #46
| License         | MIT


#### What's in this PR?

Supports more cookie date formats in the Cookie Plugin

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [x] Wait the release 1.6 of php-http/message in order to fix the composer constraint to a stable constraint
