### PR TITLE
Allow a callable parameter to decide if require is going to be retrie…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added
+
+- Added new option 'delay' for `RetryPlugin`.
+- Added new option 'decider' for `RetryPlugin`.
+
+### Changed
+
+- The `RetryPlugin` does now wait between retries. To disable/change this feature you must write something like: 
+ 
+```php
+$plugin = new RetryPlugin(['delay' => function(RequestInterface $request, Exception $e, $retries) { 
+  return 0; 
+}); 
+```
+
 ### Deprecated
 
 - The `debug_plugins` option for `PluginClient` is deprecated and will be removed in 2.0. Use the decorator design pattern instead like in [ProfilePlugin](https://github.com/php-http/HttplugBundle/blob/de33f9c14252f22093a5ec7d84f17535ab31a384/Collector/ProfilePlugin.php).

--- a/spec/Plugin/RetryPluginSpec.php
+++ b/spec/Plugin/RetryPluginSpec.php
@@ -102,7 +102,7 @@ class RetryPluginSpec extends ObjectBehavior
         $this->handleRequest($request, $next, function () {})->shouldReturnAnInstanceOf('Http\Client\Promise\HttpFulfilledPromise');
     }
 
-    function it_has_a_good_default_delay(RequestInterface $request, Exception\HttpException $exception)
+    function it_has_an_exponential_default_delay(RequestInterface $request, Exception\HttpException $exception)
     {
         $this->defaultDelay($request, $exception, 0)->shouldBe(1000);
         $this->defaultDelay($request, $exception, 1)->shouldBe(2000);

--- a/spec/Plugin/RetryPluginSpec.php
+++ b/spec/Plugin/RetryPluginSpec.php
@@ -101,4 +101,12 @@ class RetryPluginSpec extends ObjectBehavior
         $this->handleRequest($request, $next, function () {})->shouldReturnAnInstanceOf('Http\Client\Promise\HttpFulfilledPromise');
         $this->handleRequest($request, $next, function () {})->shouldReturnAnInstanceOf('Http\Client\Promise\HttpFulfilledPromise');
     }
+
+    function it_has_a_good_default_delay(RequestInterface $request, Exception\HttpException $exception)
+    {
+        $this->defaultDelay($request, $exception, 0)->shouldBe(1000);
+        $this->defaultDelay($request, $exception, 1)->shouldBe(2000);
+        $this->defaultDelay($request, $exception, 2)->shouldBe(4000);
+        $this->defaultDelay($request, $exception, 3)->shouldBe(8000);
+    }
 }

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -57,7 +57,7 @@ final class RetryPlugin implements Plugin
             'decider' => function (RequestInterface $request, Exception $e) {
                 return true;
             },
-            'delay' =>  __CLASS__.'::defaultDelay',
+            'delay' => __CLASS__.'::defaultDelay',
         ]);
         $resolver->setAllowedTypes('retries', 'int');
         $resolver->setAllowedTypes('decider', 'callable');
@@ -101,7 +101,7 @@ final class RetryPlugin implements Plugin
             usleep($time);
 
             // Retry in synchrone
-            $this->retryStorage[$chainIdentifier]++;
+            ++$this->retryStorage[$chainIdentifier];
             $promise = $this->handleRequest($request, $next, $first);
 
             return $promise->wait();
@@ -110,8 +110,8 @@ final class RetryPlugin implements Plugin
 
     /**
      * @param RequestInterface $request
-     * @param Exception $e
-     * @param int $retries The number of retries we made before. First time this get called it will be 0.
+     * @param Exception        $e
+     * @param int              $retries The number of retries we made before. First time this get called it will be 0.
      *
      * @return int
      */

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -54,10 +54,10 @@ final class RetryPlugin implements Plugin
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'retries' => 1,
-            'decider' => function(RequestInterface $request, Exception $e) {
+            'decider' => function (RequestInterface $request, Exception $e) {
                 return true;
             },
-            'delay' => function(RequestInterface $request, Exception $e, $retries) {
+            'delay' => function (RequestInterface $request, Exception $e, $retries) {
                 return ((int) pow(2, $retries - 1)) * 1000;
             },
         ]);

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -25,6 +25,16 @@ final class RetryPlugin implements Plugin
     private $retry;
 
     /**
+     * @var callable
+     */
+    private $delay;
+
+    /**
+     * @var callable
+     */
+    private $decider;
+
+    /**
      * Store the retry counter for each request.
      *
      * @var array
@@ -35,6 +45,8 @@ final class RetryPlugin implements Plugin
      * @param array $config {
      *
      *     @var int $retries Number of retries to attempt if an exception occurs before letting the exception bubble up.
+     *     @var callable $decider A callback that gets a request and an exception to decide if we should retry this or not.
+     *     @var callable $delay A callback to return how many milliseconds we should wait before trying again.
      * }
      */
     public function __construct(array $config = [])
@@ -42,11 +54,21 @@ final class RetryPlugin implements Plugin
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
             'retries' => 1,
+            'decider' => function(RequestInterface $request, Exception $e) {
+                return true;
+            },
+            'delay' => function(RequestInterface $request, Exception $e, $retries) {
+                return ((int) pow(2, $retries - 1)) * 1000;
+            },
         ]);
         $resolver->setAllowedTypes('retries', 'int');
+        $resolver->setAllowedTypes('decider', 'callable');
+        $resolver->setAllowedTypes('delay', 'callable');
         $options = $resolver->resolve($config);
 
         $this->retry = $options['retries'];
+        $this->decider = $options['decider'];
+        $this->delay = $options['delay'];
     }
 
     /**
@@ -73,7 +95,12 @@ final class RetryPlugin implements Plugin
                 throw $exception;
             }
 
-            ++$this->retryStorage[$chainIdentifier];
+            if (!call_user_func($this->decider, $request, $exception)) {
+                throw $exception;
+            }
+
+            $time = call_user_func($this->delay, $request, $exception, ++$this->retryStorage[$chainIdentifier]);
+            usleep($time);
 
             // Retry in synchrone
             $promise = $this->handleRequest($request, $next, $first);

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -117,6 +117,6 @@ final class RetryPlugin implements Plugin
      */
     public static function defaultDelay(RequestInterface $request, Exception $e, $retries)
     {
-        return ((int) pow(2, $retries)) * 1000;
+        return pow(2, $retries) * 1000;
     }
 }


### PR DESCRIPTION
…d or not.

Also allow retry backoff

This will fix #78 


It is a minor breaking change here. Instead of retry immediately we wait a second. I do not consider it a BC break though..