### PR TITLE
Do not pass client_name option to PluginClient constructor

### DIFF
--- a/spec/PluginClientFactorySpec.php
+++ b/spec/PluginClientFactorySpec.php
@@ -18,4 +18,9 @@ class PluginClientFactorySpec extends ObjectBehavior
 
         $client->shouldHaveType('Http\Client\Common\PluginClient');
     }
+
+    function it_does_not_construct_plugin_client_with_client_name_option(HttpClient $httpClient)
+    {
+        $this->createClient($httpClient, [], ['client_name' => 'Default']);
+    }
 }

--- a/src/PluginClientFactory.php
+++ b/src/PluginClientFactory.php
@@ -55,6 +55,8 @@ final class PluginClientFactory
             return $factory($client, $plugins, $options);
         }
 
+        unset($options['client_name']);
+
         return new PluginClient($client, $plugins, $options);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixup #71 
| Documentation   | n/a
| License         | MIT

In #71, I missed to remove the `client_name` option from the options array before using it as `PluginClient` constructor third argument.

Before choosing to use `unset`, I was thinking to add the `client_name` option to `PluginClient`, use the `OptionsResolver` to set a default client name and add a getter to retrieve the client name. I don't choosed this way to not change anything in `PluginClient`, but if you find this solution better than the `unset` one, I would be happy to update this PR.