### PR TITLE
Add Content-type plugin to set content-type header automatically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",
-        "henrikbjorn/phpspec-code-coverage" : "^1.0"
+        "henrikbjorn/phpspec-code-coverage" : "^1.0",
+        "guzzlehttp/psr7": "^1.4"
     },
     "suggest": {
         "php-http/logger-plugin": "PSR-3 Logger plugin",

--- a/spec/Plugin/ContentTypePluginSpec.php
+++ b/spec/Plugin/ContentTypePluginSpec.php
@@ -56,4 +56,13 @@ class ContentTypePluginSpec extends ObjectBehavior
         $this->handleRequest($request, function () {}, function () {});
     }
 
+    function it_does_not_set_content_type_header_if_size_0_or_unknown(RequestInterface $request)
+    {
+        $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for());
+        $request->withHeader('Content-Type', null)->shouldNotBeCalled();
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
 }

--- a/spec/Plugin/ContentTypePluginSpec.php
+++ b/spec/Plugin/ContentTypePluginSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace spec\Http\Client\Common\Plugin;
+
+use PhpSpec\Exception\Example\SkippingException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ContentTypePluginSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Http\Client\Common\Plugin\ContentTypePlugin');
+    }
+
+    function it_is_a_plugin()
+    {
+        $this->shouldImplement('Http\Client\Common\Plugin');
+    }
+
+    function it_adds_json_content_type_header(RequestInterface $request)
+    {
+        $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
+        $request->getBody()->shouldBeCalled()->willReturn(json_encode(['foo' => 'bar']));
+        $request->withHeader('Content-Type', 'application/json')->shouldBeCalled()->willReturn($request);
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_adds_xml_content_type_header(RequestInterface $request)
+    {
+        $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
+        $request->getBody()->shouldBeCalled()->willReturn('<foo>bar</foo>');
+        $request->withHeader('Content-Type', 'application/xml')->shouldBeCalled()->willReturn($request);
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_does_not_set_content_type_header(RequestInterface $request)
+    {
+        $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
+        $request->getBody()->shouldBeCalled()->willReturn('foo');
+        $request->withHeader('Content-Type', null)->shouldNotBeCalled();
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_does_not_set_content_type_header_if_already_one(RequestInterface $request)
+    {
+        $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(true);
+        $request->getBody()->shouldNotBeCalled()->willReturn('foo');
+        $request->withHeader('Content-Type', null)->shouldNotBeCalled();
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+}

--- a/spec/Plugin/ContentTypePluginSpec.php
+++ b/spec/Plugin/ContentTypePluginSpec.php
@@ -65,4 +65,45 @@ class ContentTypePluginSpec extends ObjectBehavior
         $this->handleRequest($request, function () {}, function () {});
     }
 
+    function it_adds_xml_content_type_header_if_size_limit_is_not_reached_using_default_value(RequestInterface $request)
+    {
+        $this->beConstructedWith([
+            'skip_detection' => true
+        ]);
+
+        $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('<foo>bar</foo>'));
+        $request->withHeader('Content-Type', 'application/xml')->shouldBeCalled()->willReturn($request);
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_adds_xml_content_type_header_if_size_limit_is_not_reached(RequestInterface $request)
+    {
+        $this->beConstructedWith([
+            'skip_detection' => true,
+            'size_limit' => 32000000
+        ]);
+
+        $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('<foo>bar</foo>'));
+        $request->withHeader('Content-Type', 'application/xml')->shouldBeCalled()->willReturn($request);
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
+    function it_does_not_set_content_type_header_if_size_limit_is_reached(RequestInterface $request)
+    {
+        $this->beConstructedWith([
+            'skip_detection' => true,
+            'size_limit' => 8
+        ]);
+
+        $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('<foo>bar</foo>'));
+        $request->withHeader('Content-Type', null)->shouldNotBeCalled();
+
+        $this->handleRequest($request, function () {}, function () {});
+    }
+
 }

--- a/spec/Plugin/ContentTypePluginSpec.php
+++ b/spec/Plugin/ContentTypePluginSpec.php
@@ -23,7 +23,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     function it_adds_json_content_type_header(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn(json_encode(['foo' => 'bar']));
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for(json_encode(['foo' => 'bar'])));
         $request->withHeader('Content-Type', 'application/json')->shouldBeCalled()->willReturn($request);
 
         $this->handleRequest($request, function () {}, function () {});
@@ -32,7 +32,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     function it_adds_xml_content_type_header(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn('<foo>bar</foo>');
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('<foo>bar</foo>'));
         $request->withHeader('Content-Type', 'application/xml')->shouldBeCalled()->willReturn($request);
 
         $this->handleRequest($request, function () {}, function () {});
@@ -41,7 +41,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     function it_does_not_set_content_type_header(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn('foo');
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('foo'));
         $request->withHeader('Content-Type', null)->shouldNotBeCalled();
 
         $this->handleRequest($request, function () {}, function () {});
@@ -50,7 +50,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     function it_does_not_set_content_type_header_if_already_one(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(true);
-        $request->getBody()->shouldNotBeCalled()->willReturn('foo');
+        $request->getBody()->shouldNotBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('foo'));
         $request->withHeader('Content-Type', null)->shouldNotBeCalled();
 
         $this->handleRequest($request, function () {}, function () {});

--- a/src/Plugin/ContentTypePlugin.php
+++ b/src/Plugin/ContentTypePlugin.php
@@ -4,6 +4,7 @@ namespace Http\Client\Common\Plugin;
 
 use Http\Client\Common\Plugin;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Allow to set the correct content type header on the request automatically only if it is not set .
@@ -42,26 +43,30 @@ final class ContentTypePlugin implements Plugin
     }
 
     /**
-     * @param $stream
+     * @param $stream StreamInterface
      *
      * @return bool
      */
     private function isJson($stream)
     {
-        json_decode($stream);
+        $stream->rewind();
+
+        json_decode($stream->getContents());
 
         return json_last_error() == JSON_ERROR_NONE;
     }
 
     /**
-     * @param $stream
+     * @param $stream StreamInterface
      *
      * @return \SimpleXMLElement|false
      */
     private function isXml($stream)
     {
+        $stream->rewind();
+
         $previousValue = libxml_use_internal_errors(true);
-        $isXml = simplexml_load_string($stream);
+        $isXml = simplexml_load_string($stream->getContents());
         libxml_use_internal_errors($previousValue);
 
         return $isXml;

--- a/src/Plugin/ContentTypePlugin.php
+++ b/src/Plugin/ContentTypePlugin.php
@@ -67,7 +67,7 @@ final class ContentTypePlugin implements Plugin
                 return $next($request);
             }
 
-            if (0 == $streamSize) {
+            if (null === $streamSize || 0 === $streamSize) {
                 return $next($request);
             }
 

--- a/src/Plugin/ContentTypePlugin.php
+++ b/src/Plugin/ContentTypePlugin.php
@@ -63,6 +63,10 @@ final class ContentTypePlugin implements Plugin
             $stream = $request->getBody();
             $streamSize = $stream->getSize();
 
+            if (!$stream->isSeekable()) {
+                return $next($request);
+            }
+
             if (0 == $streamSize) {
                 return $next($request);
             }

--- a/src/Plugin/ContentTypePlugin.php
+++ b/src/Plugin/ContentTypePlugin.php
@@ -67,11 +67,11 @@ final class ContentTypePlugin implements Plugin
                 return $next($request);
             }
 
-            if (null === $streamSize || 0 === $streamSize) {
+            if (0 === $streamSize) {
                 return $next($request);
             }
 
-            if ($this->skipDetection && $streamSize >= $this->sizeLimit) {
+            if ($this->skipDetection && (null === $streamSize || $streamSize >= $this->sizeLimit)) {
                 return $next($request);
             }
 

--- a/src/Plugin/ContentTypePlugin.php
+++ b/src/Plugin/ContentTypePlugin.php
@@ -19,6 +19,11 @@ final class ContentTypePlugin implements Plugin
     {
         if (!$request->hasHeader('Content-Type')) {
             $stream = $request->getBody();
+            $streamSize = $stream->getSize();
+
+            if (0 == $streamSize) {
+                return $next($request);
+            }
 
             if ($this->isJson($stream)) {
                 $request = $request->withHeader('Content-Type', 'application/json');

--- a/src/Plugin/ContentTypePlugin.php
+++ b/src/Plugin/ContentTypePlugin.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Http\Client\Common\Plugin;
+
+use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Allow to set the correct content type header on the request automatically only if it is not set .
+ *
+ * @author Karim Pinchon <karim.pinchon@gmail.com>
+ */
+final class ContentTypePlugin implements Plugin
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        if (!$request->hasHeader('Content-Type')) {
+            $stream = $request->getBody();
+
+            if ($this->isJson($stream)) {
+                $request = $request->withHeader('Content-Type', 'application/json');
+
+                return $next($request);
+            }
+
+            if ($this->isXml($stream)) {
+                $request = $request->withHeader('Content-Type', 'application/xml');
+
+                return $next($request);
+            }
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * @param $stream
+     *
+     * @return bool
+     */
+    private function isJson($stream)
+    {
+        json_decode($stream);
+
+        return json_last_error() == JSON_ERROR_NONE;
+    }
+
+    /**
+     * @param $stream
+     *
+     * @return \SimpleXMLElement|false
+     */
+    private function isXml($stream)
+    {
+        libxml_use_internal_errors(true);
+
+        return simplexml_load_string($stream);
+    }
+}

--- a/src/Plugin/ContentTypePlugin.php
+++ b/src/Plugin/ContentTypePlugin.php
@@ -60,8 +60,10 @@ final class ContentTypePlugin implements Plugin
      */
     private function isXml($stream)
     {
-        libxml_use_internal_errors(true);
+        $previousValue = libxml_use_internal_errors(true);
+        $isXml = simplexml_load_string($stream);
+        libxml_use_internal_errors($previousValue);
 
-        return simplexml_load_string($stream);
+        return $isXml;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #82 
| Documentation   | https://github.com/php-http/documentation/pull/204
| License         | MIT


#### What's in this PR?

Add a new plugin which allow to detect JSON and XML content in body request and automatically set the right content-type header.


#### Why?

Set the content-type header is often unpleasing and detect whether the content is JSON or XML is relatively simple so it could save time.

#### Example Usage

``` php
$contentTypePlugin = new ContentTypePlugin();

$pluginClient = new PluginClient(
    HttpClientDiscovery::find(),
    [$contentTypePlugin]
);
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x ] Documentation pull request created (if not simply a bugfix)
