### PR TITLE
RFC: update retry plugin backoff default to be more sensible

### DIFF
--- a/spec/Plugin/RetryPluginSpec.php
+++ b/spec/Plugin/RetryPluginSpec.php
@@ -104,9 +104,9 @@ class RetryPluginSpec extends ObjectBehavior
 
     function it_has_an_exponential_default_delay(RequestInterface $request, Exception\HttpException $exception)
     {
-        $this->defaultDelay($request, $exception, 0)->shouldBe(1000);
-        $this->defaultDelay($request, $exception, 1)->shouldBe(2000);
-        $this->defaultDelay($request, $exception, 2)->shouldBe(4000);
-        $this->defaultDelay($request, $exception, 3)->shouldBe(8000);
+        $this->defaultDelay($request, $exception, 0)->shouldBe(500000);
+        $this->defaultDelay($request, $exception, 1)->shouldBe(1000000);
+        $this->defaultDelay($request, $exception, 2)->shouldBe(2000000);
+        $this->defaultDelay($request, $exception, 3)->shouldBe(4000000);
     }
 }

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -46,7 +46,7 @@ final class RetryPlugin implements Plugin
      *
      *     @var int $retries Number of retries to attempt if an exception occurs before letting the exception bubble up.
      *     @var callable $decider A callback that gets a request and an exception to decide after a failure whether the request should be retried.
-     *     @var callable $delay A callback that gets a request, an exception and the number of retries and returns how many milliseconds we should wait before trying again.
+     *     @var callable $delay A callback that gets a request, an exception and the number of retries and returns how many microseconds we should wait before trying again.
      * }
      */
     public function __construct(array $config = [])
@@ -117,6 +117,6 @@ final class RetryPlugin implements Plugin
      */
     public static function defaultDelay(RequestInterface $request, Exception $e, $retries)
     {
-        return pow(2, $retries) * 1000;
+        return pow(2, $retries) * 500000;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #79
| Documentation   |
| License         | MIT

As discussed in #79, the default delay function is not very delaying at all. With 10 retries, the delays (in seconds) of the old impl are:
```
0.001
0.002
0.004
0.008
0.016
0.032
0.064
0.128
0.256
0.512
1.024
```

I've simply multiplied by 100 here, so the new delays are:
```
0.1
0.2
0.4
0.8
1.6
3.2
6.4
12.8
25.6
51.2
102.4
```

Open to other suggests for a better delay.