### PR TITLE
Allow Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php-http/httplug": "^1.1",
         "php-http/message-factory": "^1.0",
         "php-http/message": "^1.6",
-        "symfony/options-resolver": "^2.6 || ^3.0"
+        "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?
Allow Symfony/OptionsResolver 4.x installation.

#### Why?
Symfony 4 is about to be released this month (and is already in beta). There are no BC breaks in the OptionsResolver component: https://github.com/symfony/options-resolver/compare/3.4...master , so I think we can safely allow its installation.
