### PR TITLE
Add an option to only throw exception on 5XX error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Upcoming
+
+### Added
+
+ - Add an option on ErrorPlugin to only throw exception on response with 5XX status code.
+
 ## 1.7.0 - 2017-11-30
 
 ### Added 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #77 
| Documentation   | https://github.com/php-http/documentation/pull/235/
| License         | MIT

cf #77 