### PR TITLE
Use deferred to be full async in retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - AddPathPlugin no longer add prefix multiple times if a request is restarted - it now only adds the prefix if that request chain has not yet passed through the AddPathPlugin
+- RetryPlugin no longer wait for retried requests and use a deferred promise instead
 
 ## 1.7.0 - 2017-11-30
 

--- a/spec/Plugin/RetryPluginSpec.php
+++ b/spec/Plugin/RetryPluginSpec.php
@@ -30,7 +30,9 @@ class RetryPluginSpec extends ObjectBehavior
             }
         };
 
-        $this->handleRequest($request, $next, function () {})->shouldReturnAnInstanceOf('Http\Client\Promise\HttpFulfilledPromise');
+        $promise = $this->handleRequest($request, $next, function () {});
+        $promise->shouldReturnAnInstanceOf('Http\Client\Common\Deferred');
+        $promise->wait()->shouldReturn($response);
     }
 
     function it_throws_exception_on_multiple_exceptions(RequestInterface $request)
@@ -53,7 +55,7 @@ class RetryPluginSpec extends ObjectBehavior
         };
 
         $promise = $this->handleRequest($request, $next, function () {});
-        $promise->shouldReturnAnInstanceOf('Http\Client\Promise\HttpRejectedPromise');
+        $promise->shouldReturnAnInstanceOf('Http\Client\Common\Deferred');
         $promise->shouldThrow($exception2)->duringWait();
     }
 
@@ -76,7 +78,7 @@ class RetryPluginSpec extends ObjectBehavior
         };
 
         $promise = $this->handleRequest($request, $next, function () {});
-        $promise->shouldReturnAnInstanceOf('Http\Client\Promise\HttpFulfilledPromise');
+        $promise->shouldReturnAnInstanceOf('Http\Client\Common\Deferred');
         $promise->wait()->shouldReturn($response);
     }
 
@@ -98,8 +100,13 @@ class RetryPluginSpec extends ObjectBehavior
             }
         };
 
-        $this->handleRequest($request, $next, function () {})->shouldReturnAnInstanceOf('Http\Client\Promise\HttpFulfilledPromise');
-        $this->handleRequest($request, $next, function () {})->shouldReturnAnInstanceOf('Http\Client\Promise\HttpFulfilledPromise');
+        $promise = $this->handleRequest($request, $next, function () {});
+        $promise->shouldReturnAnInstanceOf('Http\Client\Common\Deferred');
+        $promise->wait()->shouldReturn($response);
+
+        $promise = $this->handleRequest($request, $next, function () {});
+        $promise->shouldReturnAnInstanceOf('Http\Client\Common\Deferred');
+        $promise->wait()->shouldReturn($response);
     }
 
     function it_has_an_exponential_default_delay(RequestInterface $request, Exception\HttpException $exception)

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -7,7 +7,7 @@ use Http\Promise\Promise;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * A deferred allow to return a promise which has not been resolved yet
+ * A deferred allow to return a promise which has not been resolved yet.
  */
 class Deferred implements Promise
 {
@@ -36,9 +36,9 @@ class Deferred implements Promise
      */
     public function then(callable $onFulfilled = null, callable $onRejected = null)
     {
-        $deferred = new Deferred($this->waitCallback);
+        $deferred = new self($this->waitCallback);
 
-        $this->onFulfilledCallbacks[] = function (ResponseInterface $response) use($onFulfilled, $deferred) {
+        $this->onFulfilledCallbacks[] = function (ResponseInterface $response) use ($onFulfilled, $deferred) {
             try {
                 if (null !== $onFulfilled) {
                     $response = $onFulfilled($response);
@@ -49,7 +49,7 @@ class Deferred implements Promise
             }
         };
 
-        $this->onRejectedCallbacks[] = function (Exception $exception) use($onRejected, $deferred) {
+        $this->onRejectedCallbacks[] = function (Exception $exception) use ($onRejected, $deferred) {
             try {
                 if (null !== $onRejected) {
                     $response = $onRejected($exception);
@@ -75,11 +75,11 @@ class Deferred implements Promise
     }
 
     /**
-     * Resolve this deferred with a Response
+     * Resolve this deferred with a Response.
      */
     public function resolve(ResponseInterface $response)
     {
-        if ($this->state !== self::PENDING) {
+        if (self::PENDING !== $this->state) {
             return;
         }
 
@@ -92,11 +92,11 @@ class Deferred implements Promise
     }
 
     /**
-     * Reject this deferred with an Exception
+     * Reject this deferred with an Exception.
      */
     public function reject(Exception $exception)
     {
-        if ($this->state !== self::PENDING) {
+        if (self::PENDING !== $this->state) {
             return;
         }
 
@@ -113,7 +113,7 @@ class Deferred implements Promise
      */
     public function wait($unwrap = true)
     {
-        if ($this->state === self::PENDING) {
+        if (self::PENDING === $this->state) {
             $callback = $this->waitCallback;
             $callback();
         }
@@ -122,7 +122,7 @@ class Deferred implements Promise
             return;
         }
 
-        if ($this->state === self::FULFILLED) {
+        if (self::FULFILLED === $this->state) {
             return $this->value;
         }
 

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Http\Client\Common;
+
+use Http\Client\Exception;
+use Http\Promise\Promise;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A deferred allow to return a promise which has not been resolved yet
+ */
+class Deferred implements Promise
+{
+    private $value;
+
+    private $failure;
+
+    private $state;
+
+    private $waitCallback;
+
+    private $onFulfilledCallbacks;
+
+    private $onRejectedCallbacks;
+
+    public function __construct(callable $waitCallback)
+    {
+        $this->waitCallback = $waitCallback;
+        $this->state = Promise::PENDING;
+        $this->onFulfilledCallbacks = [];
+        $this->onRejectedCallbacks = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function then(callable $onFulfilled = null, callable $onRejected = null)
+    {
+        $deferred = new Deferred($this->waitCallback);
+
+        $this->onFulfilledCallbacks[] = function (ResponseInterface $response) use($onFulfilled, $deferred) {
+            try {
+                if (null !== $onFulfilled) {
+                    $response = $onFulfilled($response);
+                }
+                $deferred->resolve($response);
+            } catch (Exception $exception) {
+                $deferred->reject($exception);
+            }
+        };
+
+        $this->onRejectedCallbacks[] = function (Exception $exception) use($onRejected, $deferred) {
+            try {
+                if (null !== $onRejected) {
+                    $response = $onRejected($exception);
+                    $deferred->resolve($response);
+
+                    return;
+                }
+                $deferred->reject($exception);
+            } catch (Exception $newException) {
+                $deferred->reject($newException);
+            }
+        };
+
+        return $deferred;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * Resolve this deferred with a Response
+     */
+    public function resolve(ResponseInterface $response)
+    {
+        if ($this->state !== self::PENDING) {
+            return;
+        }
+
+        $this->value = $response;
+        $this->state = self::FULFILLED;
+
+        foreach ($this->onFulfilledCallbacks as $onFulfilledCallback) {
+            $onFulfilledCallback($response);
+        }
+    }
+
+    /**
+     * Reject this deferred with an Exception
+     */
+    public function reject(Exception $exception)
+    {
+        if ($this->state !== self::PENDING) {
+            return;
+        }
+
+        $this->failure = $exception;
+        $this->state = self::REJECTED;
+
+        foreach ($this->onRejectedCallbacks as $onRejectedCallback) {
+            $onRejectedCallback($exception);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function wait($unwrap = true)
+    {
+        if ($this->state === self::PENDING) {
+            $callback = $this->waitCallback;
+            $callback();
+        }
+
+        if (!$unwrap) {
+            return;
+        }
+
+        if ($this->state === self::FULFILLED) {
+            return $this->value;
+        }
+
+        throw $this->failure;
+    }
+}

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -2,6 +2,7 @@
 
 namespace Http\Client\Common\Plugin;
 
+use Http\Client\Common\Deferred;
 use Http\Client\Common\Plugin;
 use Http\Client\Exception;
 use Psr\Http\Message\RequestInterface;
@@ -76,19 +77,30 @@ final class RetryPlugin implements Plugin
     {
         $chainIdentifier = spl_object_hash((object) $first);
 
-        return $next($request)->then(function (ResponseInterface $response) use ($request, $chainIdentifier) {
+        $promise = $next($request);
+        $deferred = new Deferred(function () use($promise) {
+            $promise->wait(false);
+        });
+
+        $onFulfilled = function (ResponseInterface $response) use ($chainIdentifier, $deferred) {
             if (array_key_exists($chainIdentifier, $this->retryStorage)) {
                 unset($this->retryStorage[$chainIdentifier]);
             }
 
+            $deferred->resolve($response);
+
             return $response;
-        }, function (Exception $exception) use ($request, $next, $first, $chainIdentifier) {
+        };
+
+        $onRejected = function (Exception $exception) use ($request, $next, $onFulfilled, &$onRejected, $chainIdentifier, $deferred) {
             if (!array_key_exists($chainIdentifier, $this->retryStorage)) {
                 $this->retryStorage[$chainIdentifier] = 0;
             }
 
             if ($this->retryStorage[$chainIdentifier] >= $this->retry) {
                 unset($this->retryStorage[$chainIdentifier]);
+
+                $deferred->reject($exception);
 
                 throw $exception;
             }
@@ -102,10 +114,15 @@ final class RetryPlugin implements Plugin
 
             // Retry in synchrone
             ++$this->retryStorage[$chainIdentifier];
-            $promise = $this->handleRequest($request, $next, $first);
 
-            return $promise->wait();
-        });
+            $next($request)->then($onFulfilled, $onRejected);
+
+            throw $exception;
+        };
+
+        $promise->then($onFulfilled, $onRejected);
+
+        return $deferred;
     }
 
     /**

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -78,7 +78,7 @@ final class RetryPlugin implements Plugin
         $chainIdentifier = spl_object_hash((object) $first);
 
         $promise = $next($request);
-        $deferred = new Deferred(function () use($promise) {
+        $deferred = new Deferred(function () use ($promise) {
             $promise->wait(false);
         });
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

#### What's in this PR?

It adds a deferred class which allow to resolve retry in an async way (no more wait call)

#### Why?

Previously using retry plugin would force async to be sync

#### Checklist

- [x] Need to updated CHANGELOG.md (wait for other PR to be merged to not have useless conflicts)
