### PR TITLE
Only add path prefix if the path does not contain it already

### DIFF
--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -19,6 +19,13 @@ final class AddPathPlugin implements Plugin
     private $uri;
 
     /**
+     * Stores identifiers of the already altered requests.
+     *
+     * @var array
+     */
+    private $alteredRequests = [];
+
+    /**
      * @param UriInterface $uri
      */
     public function __construct(UriInterface $uri)
@@ -39,10 +46,13 @@ final class AddPathPlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
-        if (0 !== strpos($request->getUri()->getPath(), $this->uri->getPath())) {
+        $identifier = spl_object_hash((object) $first);
+
+        if (!in_array($identifier, $this->alteredRequests)) {
             $request = $request->withUri($request->getUri()
                 ->withPath($this->uri->getPath().$request->getUri()->getPath())
             );
+            $this->alteredRequests[] = $identifier;
         }
 
         return $next($request);

--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -48,11 +48,11 @@ final class AddPathPlugin implements Plugin
     {
         $identifier = spl_object_hash((object) $first);
 
-        if (!in_array($identifier, $this->alteredRequests)) {
+        if (!array_key_exists($identifier, $this->alteredRequests)) {
             $request = $request->withUri($request->getUri()
                 ->withPath($this->uri->getPath().$request->getUri()->getPath())
             );
-            $this->alteredRequests[] = $identifier;
+            $this->alteredRequests[$identifier] = $identifier;
         }
 
         return $next($request);

--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -39,7 +39,7 @@ final class AddPathPlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
-        if (strpos($request->getUri()->getPath(), $this->uri->getPath()) !== 0) {
+        if (0 !== strpos($request->getUri()->getPath(), $this->uri->getPath())) {
             $request = $request->withUri($request->getUri()
                 ->withPath($this->uri->getPath().$request->getUri()->getPath())
             );

--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -39,9 +39,11 @@ final class AddPathPlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
-        $request = $request->withUri($request->getUri()
-            ->withPath($this->uri->getPath().$request->getUri()->getPath())
-        );
+        if (strpos($request->getUri()->getPath(), $this->uri->getPath()) !== 0) {
+            $request = $request->withUri($request->getUri()
+                ->withPath($this->uri->getPath().$request->getUri()->getPath())
+            );
+        }
 
         return $next($request);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #74 (revisit)
| Documentation   | -
| License         | MIT


#### What's in this PR?

This is a revisit of the #74. 

#### Why?

(Just second [my comments](https://github.com/php-http/client-common/pull/74#issuecomment-385986737) from the original PR)

If you try to restart a failed API call by calling `return $first($request)->wait()` in a plugin (ex.: when an Oauth access token expires and you want your API client to automatically resend the same request with a new access token provided by a custom Oauth auth plugin) then the current behaviour of AddPathPlugin corrupts the URL by adding the same API version prefix to the URL again.
What is the exact use case behind adding a path prefix to a path that already has the prefix anyway? I can not imagine any. 

#### Example Usage

#### Checklist

#### To Do
