### PR TITLE
Fix Cookie handling as per RFC 6265 Section 5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.8.2 (unreleased)
+
+### Changed
+
+- When multiple cookies exist, a single header with all cookies is sent as per RFC 6265 Section 5.4
+
 ## 1.8.1 - 2018-10-09
 
 ### Fixed

--- a/spec/Plugin/CookiePluginSpec.php
+++ b/spec/Plugin/CookiePluginSpec.php
@@ -51,6 +51,27 @@ class CookiePluginSpec extends ObjectBehavior
         }, function () {});
     }
 
+    function it_combines_multiple_cookies_into_one_header(RequestInterface $request, UriInterface $uri, Promise $promise)
+    {
+        $cookie = new Cookie('name', 'value', 86400, 'test.com');
+        $cookie2 = new Cookie('name2', 'value2', 86400, 'test.com');
+
+        $this->cookieJar->addCookie($cookie);
+        $this->cookieJar->addCookie($cookie2);
+
+        $request->getUri()->willReturn($uri);
+        $uri->getHost()->willReturn('test.com');
+        $uri->getPath()->willReturn('/');
+
+        $request->withAddedHeader('Cookie', 'name=value; name2=value2')->willReturn($request);
+
+        $this->handleRequest($request, function (RequestInterface $requestReceived) use ($request, $promise) {
+            if (Argument::is($requestReceived)->scoreArgument($request->getWrappedObject())) {
+                return $promise->getWrappedObject();
+            }
+        }, function () {});
+    }
+
     function it_does_not_load_cookie_if_expired(RequestInterface $request, UriInterface $uri, Promise $promise)
     {
         $cookie = new Cookie('name', 'value', null, 'test.com', false, false, null, (new \DateTime())->modify('-1 day'));

--- a/src/Plugin/CookiePlugin.php
+++ b/src/Plugin/CookiePlugin.php
@@ -38,6 +38,7 @@ final class CookiePlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
+        $cookies = [];
         foreach ($this->cookieJar->getCookies() as $cookie) {
             if ($cookie->isExpired()) {
                 continue;
@@ -55,7 +56,11 @@ final class CookiePlugin implements Plugin
                 continue;
             }
 
-            $request = $request->withAddedHeader('Cookie', sprintf('%s=%s', $cookie->getName(), $cookie->getValue()));
+            $cookies[] = sprintf('%s=%s', $cookie->getName(), $cookie->getValue());
+        }
+
+        if (!empty($cookies)) {
+            $request = $request->withAddedHeader('Cookie', implode('; ', array_unique($cookies)));
         }
 
         return $next($request)->then(function (ResponseInterface $response) use ($request) {


### PR DESCRIPTION
Concatenate multiple cookies

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #54 
| License         | MIT


#### What's in this PR?
Makes the cookie plugin only add one cookie header with all cookies separated by ;

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

#### To Do

- [x] Need to add tests - I couldn't figure out the phpspec syntax, where the RequestInterface was being created etc. But I'm willing to add if someone can give me some pseudo code.
