### PR TITLE
Remove header if there is no more encoding value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - AddPathPlugin no longer add prefix multiple times if a request is restarted - it now only adds the prefix if that request chain has not yet passed through the AddPathPlugin
 
+### Fixed
+
+- Decoder plugin will now remove header when there is no more encoding, instead of setting to an empty array
+
 ## 1.7.0 - 2017-11-30
 
 ### Added 

--- a/spec/Plugin/DecoderPluginSpec.php
+++ b/spec/Plugin/DecoderPluginSpec.php
@@ -38,7 +38,7 @@ class DecoderPluginSpec extends ObjectBehavior
         $response->getHeader('Transfer-Encoding')->willReturn(['chunked']);
         $response->getBody()->willReturn($stream);
         $response->withBody(Argument::type('Http\Message\Encoding\DechunkStream'))->willReturn($response);
-        $response->withHeader('Transfer-Encoding', [])->willReturn($response);
+        $response->withoutHeader('Transfer-Encoding')->willReturn($response);
         $response->hasHeader('Content-Encoding')->willReturn(false);
 
         $stream->isReadable()->willReturn(true);
@@ -61,7 +61,7 @@ class DecoderPluginSpec extends ObjectBehavior
         $response->getHeader('Content-Encoding')->willReturn(['gzip']);
         $response->getBody()->willReturn($stream);
         $response->withBody(Argument::type('Http\Message\Encoding\GzipDecodeStream'))->willReturn($response);
-        $response->withHeader('Content-Encoding', [])->willReturn($response);
+        $response->withoutHeader('Content-Encoding')->willReturn($response);
 
         $stream->isReadable()->willReturn(true);
         $stream->isWritable()->willReturn(false);
@@ -83,7 +83,7 @@ class DecoderPluginSpec extends ObjectBehavior
         $response->getHeader('Content-Encoding')->willReturn(['deflate']);
         $response->getBody()->willReturn($stream);
         $response->withBody(Argument::type('Http\Message\Encoding\DecompressStream'))->willReturn($response);
-        $response->withHeader('Content-Encoding', [])->willReturn($response);
+        $response->withoutHeader('Content-Encoding')->willReturn($response);
 
         $stream->isReadable()->willReturn(true);
         $stream->isWritable()->willReturn(false);

--- a/src/Plugin/DecoderPlugin.php
+++ b/src/Plugin/DecoderPlugin.php
@@ -107,7 +107,11 @@ final class DecoderPlugin implements Plugin
                 $response = $response->withBody($stream);
             }
 
-            $response = $response->withHeader($headerName, $newEncodings);
+            if (\count($newEncodings) > 0) {
+                $response = $response->withHeader($headerName, $newEncodings);
+            } else {
+                $response = $response->withoutHeader($headerName);
+            }
         }
 
         return $response;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Decoder will now remove the header instead of setting it to an empty array

#### Why?

It fixes compatibility of this plugin with https://github.com/Nyholm/psr7 (and so certainly the PSR7 standard), as it throws an exception when setting a header with an empty array, cf this line : https://github.com/Nyholm/psr7/blob/master/src/MessageTrait.php#L80
