### PR TITLE
Fix deferred when in a non async context

### DIFF
--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -3,6 +3,8 @@
 namespace Http\Client\Common;
 
 use Http\Client\Exception;
+use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
 use Http\Promise\Promise;
 use Psr\Http\Message\ResponseInterface;
 
@@ -36,6 +38,14 @@ class Deferred implements Promise
      */
     public function then(callable $onFulfilled = null, callable $onRejected = null)
     {
+        if ($this->state === self::FULFILLED) {
+            return (new HttpFulfilledPromise($this->value))->then($onFulfilled, $onRejected);
+        }
+
+        if ($this->state === self::REJECTED) {
+            return (new HttpRejectedPromise($this->failure))->then($onFulfilled, $onRejected);
+        }
+
         $deferred = new self($this->waitCallback);
 
         $this->onFulfilledCallbacks[] = function (ResponseInterface $response) use ($onFulfilled, $deferred) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #109
| License         | MIT

Should fix #109 

Do not have time to make a proper test ATM, if urgent create a ticket for the test, merge this and push a new version

For the explanation it's because fullfilled / rejected call directly the callback before returning a new one, which makes the deferred be resolved before we set the then callback (and so the new deferred will never be resolved / rejected)