### PR TITLE
Path prefix must be present

### DIFF
--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -48,7 +48,7 @@ final class AddPathPlugin implements Plugin
     {
         $identifier = spl_object_hash((object) $first);
 
-        if (!array_key_exists($identifier, $this->alteredRequests) || strpos($request->getUri()->getPath(), $this->uri->getPath()) !== 0) {
+        if (!array_key_exists($identifier, $this->alteredRequests) || 0 !== strpos($request->getUri()->getPath(), $this->uri->getPath())) {
             $request = $request->withUri($request->getUri()
                 ->withPath($this->uri->getPath().$request->getUri()->getPath())
             );

--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -48,7 +48,7 @@ final class AddPathPlugin implements Plugin
     {
         $identifier = spl_object_hash((object) $first);
 
-        if (!array_key_exists($identifier, $this->alteredRequests)) {
+        if (!array_key_exists($identifier, $this->alteredRequests) || strpos($request->getUri()->getPath(), $this->uri->getPath()) !== 0) {
             $request = $request->withUri($request->getUri()
                 ->withPath($this->uri->getPath().$request->getUri()->getPath())
             );


### PR DESCRIPTION
Make sure the path prefix is actually present even if the request has been altered before.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #103
| Documentation   | -
| License         | MIT


#### What's in this PR?

Follow up on #103.

Everything worked fine until I refactored my tests and started to use a singleton API client for offline testing. If I call the same API endpoints in the same test with the client then the first API request gets prefixed properly but the second one does not, because the generated `$identifier` is already exist in the ` $this->alteredRequests`.