### PR TITLE
[2.0] Remove plugin chain debug

### DIFF
--- a/spec/PluginClientSpec.php
+++ b/spec/PluginClientSpec.php
@@ -87,47 +87,4 @@ class PluginClientSpec extends ObjectBehavior
 
         $this->shouldThrow('Http\Client\Common\Exception\LoopException')->duringSendRequest($request);
     }
-
-    function it_injects_debug_plugins(HttpClient $httpClient, ResponseInterface $response, RequestInterface $request, Plugin $plugin0, Plugin $plugin1, Plugin $debugPlugin)
-    {
-        $plugin0
-            ->handleRequest(
-                $request,
-                Argument::type('callable'),
-                Argument::type('callable')
-            )
-            ->shouldBeCalledTimes(1)
-            ->will(function ($args) {
-                return $args[1]($args[0]);
-            })
-        ;
-        $plugin1
-            ->handleRequest(
-                $request,
-                Argument::type('callable'),
-                Argument::type('callable')
-            )
-            ->shouldBeCalledTimes(1)
-            ->will(function ($args) {
-                return $args[1]($args[0]);
-            })
-        ;
-
-        $debugPlugin
-            ->handleRequest(
-                $request,
-                Argument::type('callable'),
-                Argument::type('callable')
-            )
-            ->shouldBeCalledTimes(3)
-            ->will(function ($args) {
-                return $args[1]($args[0]);
-            })
-        ;
-
-        $httpClient->sendRequest($request)->willReturn($response);
-
-        $this->beConstructedWith($httpClient, [$plugin0, $plugin1], ['debug_plugins'=>[$debugPlugin]]);
-        $this->sendRequest($request);
-    }
 }

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -44,6 +44,7 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      * @param HttpClient|HttpAsyncClient $client
      * @param Plugin[]                   $plugins
      * @param array                      $options {
+     *
      *     @var int      $max_restarts
      * }
      *

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -44,9 +44,7 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      * @param HttpClient|HttpAsyncClient $client
      * @param Plugin[]                   $plugins
      * @param array                      $options {
-     *
      *     @var int      $max_restarts
-     *     @var Plugin[] $debug_plugins an array of plugins that are injected between each normal plugin
      * }
      *
      * @throws \RuntimeException if client is not an instance of HttpClient or HttpAsyncClient
@@ -131,16 +129,7 @@ final class PluginClient implements HttpClient, HttpAsyncClient
     {
         $firstCallable = $lastCallable = $clientCallable;
 
-        /*
-         * Inject debug plugins between each plugin.
-         */
-        $pluginListWithDebug = $this->options['debug_plugins'];
-        foreach ($pluginList as $plugin) {
-            $pluginListWithDebug[] = $plugin;
-            $pluginListWithDebug = array_merge($pluginListWithDebug, $this->options['debug_plugins']);
-        }
-
-        while ($plugin = array_pop($pluginListWithDebug)) {
+        while ($plugin = array_pop($pluginList)) {
             $lastCallable = function (RequestInterface $request) use ($plugin, $lastCallable, &$firstCallable) {
                 return $plugin->handleRequest($request, $lastCallable, $firstCallable);
             };


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | partially #115, concludes #116 
| License         | MIT

As reported in https://github.com/php-http/client-common/pull/116#issuecomment-440182100, this removes the remainder parts of `debug_plugin`.