### PR TITLE
adjust decider to not retry client errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0 (unreleased)
 
 ### Changed
+- RetryPlugin will no longer retry requests when the response failed with a HTTP code < 500.
 - Abstract method `HttpClientPool::chooseHttpClient()` has now an explicit return type (`Http\Client\Common\HttpClientPoolItem`)
 - Interface method `Plugin::handleRequest(...)` has now an explicit return type (`Http\Promise\Promise`)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | kindof
| Deprecations?   | no
| Related tickets | fixes #80 
| Documentation   | -
| License         | MIT


#### What's in this PR?

Do not retry if the error is caused by the server returning a HTTP error code indicating that the request was bad.


#### Why?

There is no point in retrying those.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

#### To Do

- [x] Unless the exception plugin is used, this plugin only acts on network errors. Should we also look at the response and retry if the response code is >= 500? => see #126
- [x] Add test in spec
