### PR TITLE
AddPathPlugin > Trim ending slash on path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - When multiple cookies exist, a single header with all cookies is sent as per RFC 6265 Section 5.4
+- AddPathPlugin will now trim of ending slashes in paths
 
 ## 1.8.1 - 2018-10-09
 

--- a/spec/Plugin/AddPathPluginSpec.php
+++ b/spec/Plugin/AddPathPluginSpec.php
@@ -46,12 +46,24 @@ class AddPathPluginSpec extends ObjectBehavior
         $this->handleRequest($request, function () {}, function () {});
     }
 
-    function it_throws_exception_on_trailing_slash(UriInterface $host)
-    {
+    function it_removes_ending_slashes(
+        RequestInterface $request,
+        UriInterface $host,
+        UriInterface $host2,
+        UriInterface $uri
+    ) {
         $host->getPath()->shouldBeCalled()->willReturn('/api/');
+        $host2->getPath()->shouldBeCalled()->willReturn('/api');
+        $host->withPath('/api')->shouldBeCalled()->willReturn($host2);
+
+        $request->getUri()->shouldBeCalled()->willReturn($uri);
+        $request->withUri($uri)->shouldBeCalled()->willReturn($request);
+
+        $uri->withPath('/api/users')->shouldBeCalled()->willReturn($uri);
+        $uri->getPath()->shouldBeCalled()->willReturn('/users');
 
         $this->beConstructedWith($host);
-        $this->shouldThrow('\LogicException')->duringInstantiation();
+        $this->handleRequest($request, function () {}, function () {});
     }
 
     function it_throws_exception_on_empty_path(UriInterface $host)

--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -35,7 +35,7 @@ final class AddPathPlugin implements Plugin
         }
 
         if ('/' === substr($uri->getPath(), -1)) {
-            throw new \LogicException('URI path cannot end with a slash.');
+            $uri = $uri->withPath(rtrim($uri->getPath(), '/'));
         }
 
         $this->uri = $uri;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Instead of throwing `new \LogicException('URI path cannot end with a slash.');` when the URI path ends with a slash, this PR will rtrim it automatically.

#### Why?

Today was a day that we merged a PR that had successful CI builds but broke during deployment. The reason? The parameters set on the server ended with a `/`.

I don't really understand the reason for throwing exceptions this hard, while they can be recovered. Every time somebody converts a Guzzle client to HTTPlug I have to warn them that we first need to change the URI's everywhere to remove the ending slashes. And sometimes that breaks for no reason.

#### Checklist

- [x] Updated CHANGELOG.md

