### PR TITLE
Fix: path prefix must check the request, not the first handler

### DIFF
--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -46,8 +46,9 @@ final class AddPathPlugin implements Plugin
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
-        $identifier = spl_object_hash((object) $first);
+        $identifier = spl_object_hash($request);
 
+        // Only add path prefix if we did not yet add the prefix on this request 
         if (!array_key_exists($identifier, $this->alteredRequests)) {
             $request = $request->withUri($request->getUri()
                 ->withPath($this->uri->getPath().$request->getUri()->getPath())


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Commit e35c5f3f74707760e1ced52f8533121b8072feb5
| License         | MIT

#### What's in this PR?
Fix the handling introduced in https://github.com/php-http/client-common/commit/e35c5f3f74707760e1ced52f8533121b8072feb5#diff-44d3f10fc0543e373abc05223f369e01

#### Why?
The add path-prefix (as mentioned in the above commit) should check if the *request* has beenalready altered, not the previous hanlder. 

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix