### PR TITLE
Remove php-cs-fixer from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "guzzlehttp/psr7": "^1.4",
         "phpspec/phpspec": "^3.4 || ^4.2",
         "phpspec/prophecy": ">=1.8",
-        "sebastian/comparator": ">=2",
-        "friendsofphp/php-cs-fixer": "^2.2"
+        "sebastian/comparator": ">=2"
     },
     "suggest": {
         "php-http/logger-plugin": "PSR-3 Logger plugin",
@@ -41,8 +40,6 @@
         }
     },
     "scripts": {
-        "cs-check": "vendor/bin/php-cs-fixer fix --dry-run",
-        "cs-fix": "vendor/bin/php-cs-fixer fix",
         "test": "vendor/bin/phpspec run",
         "test-ci": "vendor/bin/phpspec run -c phpspec.ci.yml"
     },


### PR DESCRIPTION
IMHO PHP-cs-fixer is not a dependency. It is a tool like PHPStrom. 
One should not require tools in composer.json. 