### PR TITLE
Added a way to be forward compatible with version 2.0

### DIFF
--- a/src/Plugin/ForwardCompatibilityPlugin.php
+++ b/src/Plugin/ForwardCompatibilityPlugin.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Http\Client\Common\Plugin;
+
+use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * A plugin that helps you migrate from php-http/client-common 1.x to 2.x. This
+ * will also help you to support PHP5 at the same time you support 2.x.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+abstract class ForwardCompatibilityPlugin implements Plugin
+{
+    abstract function doHandleRequest(RequestInterface $request, callable $next, callable $first);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        return $this->doHandleRequest($request, $next, $first);
+    }
+}

--- a/src/Plugin/VersionBridgePlugin.php
+++ b/src/Plugin/VersionBridgePlugin.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\RequestInterface;
  */
 abstract class VersionBridgePlugin implements Plugin
 {
-    abstract function doHandleRequest(RequestInterface $request, callable $next, callable $first);
+    abstract protected function doHandleRequest(RequestInterface $request, callable $next, callable $first);
 
     /**
      * {@inheritdoc}

--- a/src/Plugin/VersionBridgePlugin.php
+++ b/src/Plugin/VersionBridgePlugin.php
@@ -15,9 +15,6 @@ abstract class VersionBridgePlugin implements Plugin
 {
     abstract protected function doHandleRequest(RequestInterface $request, callable $next, callable $first);
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
         return $this->doHandleRequest($request, $next, $first);

--- a/src/Plugin/VersionBridgePlugin.php
+++ b/src/Plugin/VersionBridgePlugin.php
@@ -2,7 +2,6 @@
 
 namespace Http\Client\Common\Plugin;
 
-use Http\Client\Common\Plugin;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/src/Plugin/VersionBridgePlugin.php
+++ b/src/Plugin/VersionBridgePlugin.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-abstract class ForwardCompatibilityPlugin implements Plugin
+abstract class VersionBridgePlugin implements Plugin
 {
     abstract function doHandleRequest(RequestInterface $request, callable $next, callable $first);
 

--- a/src/Plugin/VersionBridgePlugin.php
+++ b/src/Plugin/VersionBridgePlugin.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-abstract class VersionBridgePlugin implements Plugin
+trait VersionBridgePlugin
 {
     abstract protected function doHandleRequest(RequestInterface $request, callable $next, callable $first);
 

--- a/src/VersionBridgeClient.php
+++ b/src/VersionBridgeClient.php
@@ -1,11 +1,9 @@
 <?php
 
-namespace Http\Client\Common\Plugin;
+namespace Http\Client\Common;
 
-use Http\Client\Common\Plugin;
 use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * A client that helps you migrate from php-http/httplug 1.x to 2.x. This

--- a/src/VersionBridgeClient.php
+++ b/src/VersionBridgeClient.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 abstract class VersionBridgeClient implements HttpClient
 {
-    abstract public function doSendRequest(RequestInterface $request);
+    abstract protected function doSendRequest(RequestInterface $request);
 
     public function sendRequest(RequestInterface $request)
     {

--- a/src/VersionBridgeClient.php
+++ b/src/VersionBridgeClient.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Http\Client\Common\Plugin;
+
+use Http\Client\Common\Plugin;
+use Http\Client\HttpClient;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A client that helps you migrate from php-http/httplug 1.x to 2.x. This
+ * will also help you to support PHP5 at the same time you support 2.x.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+abstract class VersionBridgeClient implements HttpClient
+{
+    abstract public function doSendRequest(RequestInterface $request);
+
+    public function sendRequest(RequestInterface $request)
+    {
+        return $this->doSendRequest($request);
+    }
+}

--- a/src/VersionBridgeClient.php
+++ b/src/VersionBridgeClient.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-abstract class VersionBridgeClient implements HttpClient
+trait VersionBridgeClient
 {
     abstract protected function doSendRequest(RequestInterface $request);
 

--- a/src/VersionBridgeClient.php
+++ b/src/VersionBridgeClient.php
@@ -2,7 +2,6 @@
 
 namespace Http\Client\Common;
 
-use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
 
 /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT

To avoid updating all our plugins and the HTTPlug bundle, we can be forward compatible. 
https://3v4l.org/pn47M
https://3v4l.org/2kgtG