### PR TITLE
rename decider to exception_decider to make room for response_decider in version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.9.0 - [unreleased]
+
+### Changed
+
+- [RetryPlugin] Renamed the configuration options for the exception retry callback from `decider` to `exception_decider`
+  and `delay` to `exception_delay`. The old names still work but are deprecated.
+
 ## 1.8.2 - 2018-12-14
 
 ### Changed

--- a/spec/Plugin/RetryPluginSpec.php
+++ b/spec/Plugin/RetryPluginSpec.php
@@ -80,6 +80,30 @@ class RetryPluginSpec extends ObjectBehavior
         $promise->wait()->shouldReturn($response);
     }
 
+    function it_respects_custom_exception_decider(RequestInterface $request, ResponseInterface $response)
+    {
+        $this->beConstructedWith([
+            'exception_decider' => function (RequestInterface $request, Exception $e) {
+                return false;
+            }
+        ]);
+        $exception = new Exception\NetworkException('Exception', $request->getWrappedObject());
+
+        $called = false;
+        $next  = function (RequestInterface $receivedRequest) use($exception, &$called) {
+            if ($called) {
+                throw new \RuntimeException('Did not expect to be called multiple times');
+            }
+            $called = true;
+
+            return new HttpRejectedPromise($exception);
+        };
+
+        $promise = $this->handleRequest($request, $next, function () {});
+        $promise->shouldReturnAnInstanceOf('Http\Client\Promise\HttpRejectedPromise');
+        $promise->shouldThrow($exception)->duringWait();
+    }
+
     function it_does_not_keep_history_of_old_failure(RequestInterface $request, ResponseInterface $response)
     {
         $exception = new Exception\NetworkException('Exception 1', $request->getWrappedObject());


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | preparation for #139
| Documentation   | Callbacks are generally not documented at http://docs.php-http.org/en/latest/plugins/retry.html ...
| License         | MIT


#### What's in this PR?

Rename callback method in retry plugin options.


#### Why?

Make room for response decider in version 2.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- not needed

