### PR TITLE
Make sure we can use PSR-18 clients in version 1.x

### DIFF
--- a/src/BatchClient.php
+++ b/src/BatchClient.php
@@ -5,6 +5,7 @@ namespace Http\Client\Common;
 use Http\Client\Exception;
 use Http\Client\HttpClient;
 use Http\Client\Common\Exception\BatchException;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -17,15 +18,19 @@ use Psr\Http\Message\RequestInterface;
 class BatchClient implements HttpClient
 {
     /**
-     * @var HttpClient
+     * @var HttpClient|ClientInterface
      */
     private $client;
 
     /**
-     * @param HttpClient $client
+     * @param HttpClient|ClientInterface  $client
      */
-    public function __construct(HttpClient $client)
+    public function __construct($client)
     {
+        if (!($client instanceof HttpClient) && !($client instanceof ClientInterface)) {
+            throw new \LogicException('Client must be an instance of Http\\Client\\HttpClient or Psr\\Http\\Client\\ClientInterface');
+        }
+
         $this->client = $client;
     }
 

--- a/src/EmulatedHttpAsyncClient.php
+++ b/src/EmulatedHttpAsyncClient.php
@@ -4,6 +4,7 @@ namespace Http\Client\Common;
 
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 
 /**
  * Emulates an async HTTP client.
@@ -18,10 +19,14 @@ class EmulatedHttpAsyncClient implements HttpClient, HttpAsyncClient
     use HttpClientDecorator;
 
     /**
-     * @param HttpClient $httpClient
+     * @param HttpClient|ClientInterface $httpClient
      */
-    public function __construct(HttpClient $httpClient)
+    public function __construct($httpClient)
     {
+        if (!($httpClient instanceof HttpClient) && !($httpClient instanceof ClientInterface)) {
+            throw new \LogicException('Client must be an instance of Http\\Client\\HttpClient or Psr\\Http\\Client\\ClientInterface');
+        }
+
         $this->httpClient = $httpClient;
     }
 }

--- a/src/FlexibleHttpClient.php
+++ b/src/FlexibleHttpClient.php
@@ -18,7 +18,7 @@ final class FlexibleHttpClient implements HttpClient, HttpAsyncClient
     use HttpAsyncClientDecorator;
 
     /**
-     * @param HttpClient|HttpAsyncClient $client
+     * @param HttpClient|HttpAsyncClient|ClientInterface $client
      */
     public function __construct($client)
     {

--- a/src/FlexibleHttpClient.php
+++ b/src/FlexibleHttpClient.php
@@ -4,6 +4,7 @@ namespace Http\Client\Common;
 
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 
 /**
  * A flexible http client, which implements both interface and will emulate
@@ -21,14 +22,14 @@ final class FlexibleHttpClient implements HttpClient, HttpAsyncClient
      */
     public function __construct($client)
     {
-        if (!($client instanceof HttpClient) && !($client instanceof HttpAsyncClient)) {
+        if (!($client instanceof HttpClient) && !($client instanceof HttpAsyncClient) && !($client instanceof ClientInterface)) {
             throw new \LogicException('Client must be an instance of Http\\Client\\HttpClient or Http\\Client\\HttpAsyncClient');
         }
 
         $this->httpClient = $client;
         $this->httpAsyncClient = $client;
 
-        if (!($this->httpClient instanceof HttpClient)) {
+        if (!($this->httpClient instanceof HttpClient) && !($client instanceof ClientInterface)) {
             $this->httpClient = new EmulatedHttpClient($this->httpClient);
         }
 

--- a/src/HttpClientDecorator.php
+++ b/src/HttpClientDecorator.php
@@ -3,6 +3,7 @@
 namespace Http\Client\Common;
 
 use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -13,7 +14,7 @@ use Psr\Http\Message\RequestInterface;
 trait HttpClientDecorator
 {
     /**
-     * @var HttpClient
+     * @var HttpClient|ClientInterface
      */
     protected $httpClient;
 

--- a/src/HttpMethodsClient.php
+++ b/src/HttpMethodsClient.php
@@ -5,6 +5,7 @@ namespace Http\Client\Common;
 use Http\Client\Exception;
 use Http\Client\HttpClient;
 use Http\Message\RequestFactory;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -27,7 +28,7 @@ use Psr\Http\Message\UriInterface;
 class HttpMethodsClient implements HttpClient
 {
     /**
-     * @var HttpClient
+     * @var HttpClient|ClientInterface
      */
     private $httpClient;
 
@@ -37,11 +38,15 @@ class HttpMethodsClient implements HttpClient
     private $requestFactory;
 
     /**
-     * @param HttpClient     $httpClient     The client to send requests with
-     * @param RequestFactory $requestFactory The message factory to create requests
+     * @param HttpClient|ClientInterface $httpClient     The client to send requests with
+     * @param RequestFactory             $requestFactory The message factory to create requests
      */
-    public function __construct(HttpClient $httpClient, RequestFactory $requestFactory)
+    public function __construct($httpClient, RequestFactory $requestFactory)
     {
+        if (!($httpClient instanceof HttpClient) && !($httpClient instanceof ClientInterface)) {
+            throw new \LogicException('Client must be an instance of Http\\Client\\HttpClient or Psr\\Http\\Client\\ClientInterface');
+        }
+
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
     }

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -8,6 +8,7 @@ use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Client\Promise\HttpFulfilledPromise;
 use Http\Client\Promise\HttpRejectedPromise;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -54,7 +55,7 @@ final class PluginClient implements HttpClient, HttpAsyncClient
     {
         if ($client instanceof HttpAsyncClient) {
             $this->client = $client;
-        } elseif ($client instanceof HttpClient) {
+        } elseif ($client instanceof HttpClient || $client instanceof ClientInterface) {
             $this->client = new EmulatedHttpAsyncClient($client);
         } else {
             throw new \RuntimeException('Client must be an instance of Http\\Client\\HttpClient or Http\\Client\\HttpAsyncClient');

--- a/src/PluginClientFactory.php
+++ b/src/PluginClientFactory.php
@@ -4,6 +4,7 @@ namespace Http\Client\Common;
 
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 
 /**
  * Factory to create PluginClient instances. Using this factory instead of calling PluginClient constructor will enable
@@ -35,9 +36,9 @@ final class PluginClientFactory
     }
 
     /**
-     * @param HttpClient|HttpAsyncClient $client
-     * @param Plugin[]                   $plugins
-     * @param array                      $options {
+     * @param HttpClient|HttpAsyncClient|ClientInterface $client
+     * @param Plugin[]                                   $plugins
+     * @param array                                      $options {
      *
      *     @var string $client_name to give client a name which may be used when displaying client information  like in
      *         the HTTPlugBundle profiler.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT

Our 2.x branch is compatible with PSR-18. The master branch should also be compatible. 

Ive ipdated all places where we are **consuming** a httplug client. They do now support both httplug 1.x and PSR-18.

FYI @gmponos 