### PR TITLE
Added test to highlight a bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ jobs:
     env: DEPENDENCIES="dunglas/symfony-lock:^3"
   - php: 7.2
     env: DEPENDENCIES="dunglas/symfony-lock:^4"
+  - php: 7.2
+    env: TEST_COMMAND="./vendor/bin/phpunit" DEPENDENCIES="phpunit/phpunit:^7.5 nyholm/psr7:^1.0"
 
     # Latest dev release
   - php: 7.3

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="./vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true">
+
+    <testsuites>
+        <testsuite name="HTTPlug unit tests">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/PluginClientTest.php
+++ b/tests/PluginClientTest.php
@@ -33,31 +33,34 @@ class PluginClientTest extends TestCase
 
     public function clientAndMethodProvider()
     {
-        $syncClient = new class implements ClientInterface {
+        $syncClient = new class() implements ClientInterface {
             public function sendRequest(RequestInterface $request): ResponseInterface
             {
                 return new Response();
             }
         };
 
-        $asyncClient = new class implements HttpAsyncClient {
+        $asyncClient = new class() implements HttpAsyncClient {
             public function sendAsyncRequest(RequestInterface $request)
             {
                 return new HttpFulfilledPromise(new Response());
             }
         };
 
-        $headerAppendPlugin = new HeaderAppendPlugin(['Content-Type'=>'text/html']);
+        $headerAppendPlugin = new HeaderAppendPlugin(['Content-Type' => 'text/html']);
         $redirectPlugin = new RedirectPlugin();
-        $restartOncePlugin = new class implements Plugin {
+        $restartOncePlugin = new class() implements Plugin {
             private $firstRun = true;
 
             public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
             {
                 if ($this->firstRun) {
                     $this->firstRun = false;
-                    return $first($request)->wait();
+
+                    return $first($request);
                 }
+                $this->firstRun = true;
+
                 return $next($request);
             }
         };

--- a/tests/PluginClientTest.php
+++ b/tests/PluginClientTest.php
@@ -4,15 +4,73 @@ declare(strict_types=1);
 
 namespace tests\Http\Client\Common;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\HeaderAppendPlugin;
+use Http\Client\Common\Plugin\RedirectPlugin;
+use Http\Client\Common\PluginClient;
+use Http\Client\HttpAsyncClient;
+use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Promise\Promise;
+use Nyholm\Psr7\Request;
+use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class PluginClientTest extends TestCase
 {
-    private $syncClient;
-    private $asyncClient;
-
-    protected function setUp()
+    /**
+     * @dataProvider clientAndMethodProvider
+     */
+    public function testRestartChain(PluginClient $client, string $method, string $returnType)
     {
+        $request = new Request('GET', 'https://example.com');
+        $result = call_user_func([$client, $method], $request);
 
+        $this->assertInstanceOf($returnType, $result);
+    }
+
+    public function clientAndMethodProvider()
+    {
+        $syncClient = new class implements ClientInterface {
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                return new Response();
+            }
+        };
+
+        $asyncClient = new class implements HttpAsyncClient {
+            public function sendAsyncRequest(RequestInterface $request)
+            {
+                return new HttpFulfilledPromise(new Response());
+            }
+        };
+
+        $headerAppendPlugin = new HeaderAppendPlugin(['Content-Type'=>'text/html']);
+        $redirectPlugin = new RedirectPlugin();
+        $restartOncePlugin = new class implements Plugin {
+            private $firstRun = true;
+
+            public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+            {
+                if ($this->firstRun) {
+                    $this->firstRun = false;
+                    return $first($request)->wait();
+                }
+                return $next($request);
+            }
+        };
+
+        $plugins = [$headerAppendPlugin, $restartOncePlugin, $redirectPlugin];
+
+        $pluginClient = new PluginClient($syncClient, $plugins);
+        yield [$pluginClient, 'sendRequest', ResponseInterface::class];
+        yield [$pluginClient, 'sendAsyncRequest', Promise::class];
+
+        // Async
+        $pluginClient = new PluginClient($asyncClient, $plugins);
+        yield [$pluginClient, 'sendRequest', ResponseInterface::class];
+        yield [$pluginClient, 'sendAsyncRequest', Promise::class];
     }
 }

--- a/tests/PluginClientTest.php
+++ b/tests/PluginClientTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Http\Client\Common;
+
+use PHPUnit\Framework\TestCase;
+
+class PluginClientTest extends TestCase
+{
+    private $syncClient;
+    private $asyncClient;
+
+    protected function setUp()
+    {
+
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

I found a bug. The bug is present all these are true: 
- We use a synchronous client
- We use a synchronous request
- We have a plugin that use `return $first($request)->wait()`

HOWEVER, using `return $first($request)->wait()` does not make any sense...
I got the idea from #103 but after writing this PR and https://github.com/php-http/client-common/pull/103#issuecomment-450636634 I discovered that there is no bug and one should never do `return $first($request)->wait()`. 

Im not sure we want to merge this test or not. I kind of like the code so I did not want to throw it away =)