### PR TITLE
A better branch alias would be 2.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
Better, so that composer can't load the master branch in place of 2.1.x, since master is actually 2.0.x.