### PR TITLE
Added HttpClientNoMatchException for HttpClientRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0 (unreleased)
 
 ### Changed
+- HttpClientRouter now throws a HttpClientNoMatchException instead of a RequestException if it can not find a client for the request.
 - RetryPlugin will no longer retry requests when the response failed with a HTTP code < 500.
 - Abstract method `HttpClientPool::chooseHttpClient()` has now an explicit return type (`Http\Client\Common\HttpClientPoolItem`)
 - Interface method `Plugin::handleRequest(...)` has now an explicit return type (`Http\Promise\Promise`)

--- a/spec/HttpClientRouterSpec.php
+++ b/spec/HttpClientRouterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\Exception\HttpClientNoMatchException;
 use Http\Client\Common\HttpClientRouter;
 use Http\Message\RequestMatcher;
 use Http\Client\HttpAsyncClient;
@@ -58,7 +59,7 @@ class HttpClientRouterSpec extends ObjectBehavior
         $this->addClient($client, $matcher);
         $matcher->matches($request)->willReturn(false);
 
-        $this->shouldThrow(RequestException::class)->duringSendRequest($request);
+        $this->shouldThrow(HttpClientNoMatchException::class)->duringSendRequest($request);
     }
 
     public function it_throw_exception_on_send_async_request(RequestMatcher $matcher, HttpAsyncClient $client, RequestInterface $request)
@@ -66,6 +67,6 @@ class HttpClientRouterSpec extends ObjectBehavior
         $this->addClient($client, $matcher);
         $matcher->matches($request)->willReturn(false);
 
-        $this->shouldThrow(RequestException::class)->duringSendAsyncRequest($request);
+        $this->shouldThrow(HttpClientNoMatchException::class)->duringSendAsyncRequest($request);
     }
 }

--- a/spec/HttpClientRouterSpec.php
+++ b/spec/HttpClientRouterSpec.php
@@ -12,7 +12,6 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
 use Http\Client\Common\HttpClientRouterInterface;
-use Http\Client\Exception\RequestException;
 
 class HttpClientRouterSpec extends ObjectBehavior
 {

--- a/src/Exception/HttpClientNoMatchException.php
+++ b/src/Exception/HttpClientNoMatchException.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\RequestInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class HttpClientNoMatchException extends TransferException
+final class HttpClientNoMatchException extends TransferException
 {
     private $request;
 

--- a/src/Exception/HttpClientNoMatchException.php
+++ b/src/Exception/HttpClientNoMatchException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Client\Common\Exception;
+
+use Http\Client\Exception\TransferException;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Thrown when a http client match in the HTTPClientRouter.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class HttpClientNoMatchException extends TransferException
+{
+    private $request;
+
+    public function __construct(string $message, RequestInterface $request, \Exception $previous = null)
+    {
+        $this->request = $request;
+
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+}

--- a/src/HttpClientRouter.php
+++ b/src/HttpClientRouter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Http\Client\Common;
 
-use Http\Client\Exception\RequestException;
+use Http\Client\Common\Exception\HttpClientNoMatchException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Message\RequestMatcher;
@@ -66,6 +66,6 @@ final class HttpClientRouter implements HttpClientRouterInterface
             }
         }
 
-        throw new RequestException('No client found for the specified request', $request);
+        throw new HttpClientNoMatchException('No client found for the specified request', $request);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #44 
| Documentation   | 
| License         | MIT
