### PR TITLE
type declarations for php 7.1

### DIFF
--- a/spec/Plugin/ErrorPluginSpec.php
+++ b/spec/Plugin/ErrorPluginSpec.php
@@ -27,7 +27,7 @@ class ErrorPluginSpec extends ObjectBehavior
 
     public function it_throw_client_error_exception_on_4xx_error(RequestInterface $request, ResponseInterface $response)
     {
-        $response->getStatusCode()->willReturn('400');
+        $response->getStatusCode()->willReturn(400);
         $response->getReasonPhrase()->willReturn('Bad request');
 
         $next = function (RequestInterface $receivedRequest) use ($request, $response) {
@@ -45,7 +45,7 @@ class ErrorPluginSpec extends ObjectBehavior
     {
         $this->beConstructedWith(['only_server_exception' => true]);
 
-        $response->getStatusCode()->willReturn('400');
+        $response->getStatusCode()->willReturn(400);
         $response->getReasonPhrase()->willReturn('Bad request');
 
         $next = function (RequestInterface $receivedRequest) use ($request, $response) {
@@ -59,7 +59,7 @@ class ErrorPluginSpec extends ObjectBehavior
 
     public function it_throw_server_error_exception_on_5xx_error(RequestInterface $request, ResponseInterface $response)
     {
-        $response->getStatusCode()->willReturn('500');
+        $response->getStatusCode()->willReturn(500);
         $response->getReasonPhrase()->willReturn('Server error');
 
         $next = function (RequestInterface $receivedRequest) use ($request, $response) {
@@ -75,7 +75,7 @@ class ErrorPluginSpec extends ObjectBehavior
 
     public function it_returns_response(RequestInterface $request, ResponseInterface $response)
     {
-        $response->getStatusCode()->willReturn('200');
+        $response->getStatusCode()->willReturn(200);
 
         $next = function (RequestInterface $receivedRequest) use ($request, $response) {
             if (Argument::is($request->getWrappedObject())->scoreArgument($receivedRequest)) {

--- a/spec/Plugin/RedirectPluginSpec.php
+++ b/spec/Plugin/RedirectPluginSpec.php
@@ -37,7 +37,7 @@ class RedirectPluginSpec extends ObjectBehavior
         ResponseInterface $finalResponse,
         Promise $promise
     ) {
-        $responseRedirect->getStatusCode()->willReturn('302');
+        $responseRedirect->getStatusCode()->willReturn(302);
         $responseRedirect->hasHeader('Location')->willReturn(true);
         $responseRedirect->getHeaderLine('Location')->willReturn('/redirect');
 
@@ -156,7 +156,7 @@ class RedirectPluginSpec extends ObjectBehavior
         $request->getUri()->willReturn($uri);
         $uri->__toString()->willReturn('/original');
 
-        $responseRedirect->getStatusCode()->willReturn('302');
+        $responseRedirect->getStatusCode()->willReturn(302);
         $responseRedirect->hasHeader('Location')->willReturn(true);
         $responseRedirect->getHeaderLine('Location')->willReturn('https://server.com:8000/redirect?query#fragment');
 
@@ -203,7 +203,7 @@ class RedirectPluginSpec extends ObjectBehavior
 
         $request->getUri()->willReturn($uri);
         $uri->__toString()->willReturn('/original');
-        $responseRedirect->getStatusCode()->willReturn('302');
+        $responseRedirect->getStatusCode()->willReturn(302);
         $responseRedirect->hasHeader('Location')->willReturn(false);
 
         $promise = $this->handleRequest($request, $next, function () {});
@@ -223,7 +223,7 @@ class RedirectPluginSpec extends ObjectBehavior
         $uri->__toString()->willReturn('/original');
         $responseRedirect->getHeaderLine('Location')->willReturn('scheme:///invalid');
 
-        $responseRedirect->getStatusCode()->willReturn('302');
+        $responseRedirect->getStatusCode()->willReturn(302);
         $responseRedirect->hasHeader('Location')->willReturn(true);
 
         $promise = $this->handleRequest($request, $next, function () {});
@@ -240,7 +240,7 @@ class RedirectPluginSpec extends ObjectBehavior
         };
 
         $this->beConstructedWith(['preserve_header' => true, 'use_default_for_multiple' => false]);
-        $responseRedirect->getStatusCode()->willReturn('300');
+        $responseRedirect->getStatusCode()->willReturn(300);
 
         $promise = $this->handleRequest($request, $next, function () {});
         $promise->shouldReturnAnInstanceOf(HttpRejectedPromise::class);
@@ -255,7 +255,7 @@ class RedirectPluginSpec extends ObjectBehavior
             }
         };
 
-        $responseRedirect->getStatusCode()->willReturn('300');
+        $responseRedirect->getStatusCode()->willReturn(300);
         $responseRedirect->hasHeader('Location')->willReturn(false);
 
         $promise = $this->handleRequest($request, $next, function () {});
@@ -275,7 +275,7 @@ class RedirectPluginSpec extends ObjectBehavior
         $request->getUri()->willReturn($uri);
         $uri->__toString()->willReturn('/original');
 
-        $responseRedirect->getStatusCode()->willReturn('302');
+        $responseRedirect->getStatusCode()->willReturn(302);
         $responseRedirect->hasHeader('Location')->willReturn(true);
         $responseRedirect->getHeaderLine('Location')->willReturn('/redirect');
 
@@ -324,7 +324,7 @@ class RedirectPluginSpec extends ObjectBehavior
         $request->getUri()->willReturn($uri);
         $uri->__toString()->willReturn('/original');
 
-        $responseRedirect->getStatusCode()->willReturn('302');
+        $responseRedirect->getStatusCode()->willReturn(302);
         $responseRedirect->hasHeader('Location')->willReturn(true);
         $responseRedirect->getHeaderLine('Location')->willReturn('/redirect');
 
@@ -468,7 +468,7 @@ class RedirectPluginSpec extends ObjectBehavior
         ResponseInterface $finalResponse,
         Promise $promise
     ) {
-        $responseRedirect->getStatusCode()->willReturn('302');
+        $responseRedirect->getStatusCode()->willReturn(302);
         $responseRedirect->hasHeader('Location')->willReturn(true);
         $responseRedirect->getHeaderLine('Location')->willReturn('https://my-site.com/original');
 

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -79,7 +79,7 @@ final class Deferred implements Promise
     /**
      * Resolve this deferred with a Response.
      */
-    public function resolve(ResponseInterface $response)
+    public function resolve(ResponseInterface $response): void
     {
         if (self::PENDING !== $this->state) {
             return;
@@ -96,7 +96,7 @@ final class Deferred implements Promise
     /**
      * Reject this deferred with an Exception.
      */
-    public function reject(Exception $exception)
+    public function reject(Exception $exception): void
     {
         if (self::PENDING !== $this->state) {
             return;

--- a/src/Exception/BatchException.php
+++ b/src/Exception/BatchException.php
@@ -28,10 +28,8 @@ final class BatchException extends TransferException
 
     /**
      * Returns the BatchResult that contains all responses and exceptions.
-     *
-     * @return BatchResult
      */
-    public function getResult()
+    public function getResult(): BatchResult
     {
         return $this->result;
     }

--- a/src/HttpClientPool.php
+++ b/src/HttpClientPool.php
@@ -20,5 +20,5 @@ interface HttpClientPool extends HttpAsyncClient, HttpClient
      *
      * @param ClientInterface|HttpAsyncClient|HttpClientPoolItem $client
      */
-    public function addHttpClient($client);
+    public function addHttpClient($client): void;
 }

--- a/src/HttpClientPool/HttpClientPool.php
+++ b/src/HttpClientPool/HttpClientPool.php
@@ -27,7 +27,7 @@ abstract class HttpClientPool implements HttpClientPoolInterface
      *
      * @param ClientInterface|HttpAsyncClient|HttpClientPoolItem $client
      */
-    public function addHttpClient($client)
+    public function addHttpClient($client): void
     {
         if (!$client instanceof HttpClientPoolItem) {
             $client = new HttpClientPoolItem($client);

--- a/src/HttpClientPool/HttpClientPoolItem.php
+++ b/src/HttpClientPool/HttpClientPoolItem.php
@@ -144,7 +144,7 @@ class HttpClientPoolItem implements HttpClient, HttpAsyncClient
     /**
      * Increment the request count.
      */
-    private function incrementRequestCount()
+    private function incrementRequestCount(): void
     {
         ++$this->sendingRequestCount;
     }
@@ -152,7 +152,7 @@ class HttpClientPoolItem implements HttpClient, HttpAsyncClient
     /**
      * Decrement the request count.
      */
-    private function decrementRequestCount()
+    private function decrementRequestCount(): void
     {
         --$this->sendingRequestCount;
     }
@@ -160,7 +160,7 @@ class HttpClientPoolItem implements HttpClient, HttpAsyncClient
     /**
      * Enable the current client.
      */
-    private function enable()
+    private function enable(): void
     {
         $this->disabledAt = null;
     }
@@ -168,7 +168,7 @@ class HttpClientPoolItem implements HttpClient, HttpAsyncClient
     /**
      * Disable the current client.
      */
-    private function disable()
+    private function disable(): void
     {
         $this->disabledAt = new \DateTime('now');
     }

--- a/src/HttpClientRouter.php
+++ b/src/HttpClientRouter.php
@@ -45,7 +45,7 @@ final class HttpClientRouter implements HttpClientRouterInterface
      *
      * @param HttpClient|HttpAsyncClient $client
      */
-    public function addClient($client, RequestMatcher $requestMatcher)
+    public function addClient($client, RequestMatcher $requestMatcher): void
     {
         $this->clients[] = [
             'matcher' => $requestMatcher,

--- a/src/HttpClientRouterInterface.php
+++ b/src/HttpClientRouterInterface.php
@@ -23,5 +23,5 @@ interface HttpClientRouterInterface extends HttpClient, HttpAsyncClient
      *
      * @param ClientInterface|HttpAsyncClient $client
      */
-    public function addClient($client, RequestMatcher $requestMatcher);
+    public function addClient($client, RequestMatcher $requestMatcher): void;
 }

--- a/src/HttpMethodsClient.php
+++ b/src/HttpMethodsClient.php
@@ -71,7 +71,7 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
         return $this->send('OPTIONS', $uri, $headers, $body);
     }
 
-    public function send($method, $uri, array $headers = [], $body = null): ResponseInterface
+    public function send(string $method, $uri, array $headers = [], $body = null): ResponseInterface
     {
         return $this->sendRequest($this->requestFactory->createRequest(
             $method,

--- a/src/HttpMethodsClientInterface.php
+++ b/src/HttpMethodsClientInterface.php
@@ -112,5 +112,5 @@ interface HttpMethodsClientInterface extends HttpClient
      *
      * @throws Exception
      */
-    public function send($method, $uri, array $headers = [], $body = null): ResponseInterface;
+    public function send(string $method, $uri, array $headers = [], $body = null): ResponseInterface;
 }

--- a/src/Plugin/AddHostPlugin.php
+++ b/src/Plugin/AddHostPlugin.php
@@ -66,7 +66,7 @@ final class AddHostPlugin implements Plugin
         return $next($request);
     }
 
-    private function configureOptions(OptionsResolver $resolver)
+    private function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'replace' => false,

--- a/src/Plugin/CookiePlugin.php
+++ b/src/Plugin/CookiePlugin.php
@@ -91,11 +91,9 @@ final class CookiePlugin implements Plugin
     /**
      * Creates a cookie from a string.
      *
-     * @return Cookie|null
-     *
      * @throws TransferException
      */
-    private function createCookie(RequestInterface $request, string $setCookieHeader)
+    private function createCookie(RequestInterface $request, string $setCookieHeader): ?Cookie
     {
         $parts = array_map('trim', explode(';', $setCookieHeader));
 
@@ -168,6 +166,8 @@ final class CookiePlugin implements Plugin
      * Separates key/value pair from cookie.
      *
      * @param string $part A single cookie value in format key=value
+     *
+     * @return string[]
      */
     private function createValueKey(string $part): array
     {


### PR DESCRIPTION
some more strict types where we can. the `: void` is useful for tools that report when the return value of a void method is being used.