### PR TITLE
Add plugin client builder

### DIFF
--- a/src/PluginClientBuilder.php
+++ b/src/PluginClientBuilder.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Client\Common;
+
+use Http\Client\HttpAsyncClient;
+use Psr\Http\Client\ClientInterface;
+
+/**
+ * Build an instance of a PluginClient with a dynamic list of plugins.
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+final class PluginClientBuilder
+{
+    /** @var Plugin[][] List of plugins ordered by priority [priority => Plugin[]]). */
+    private $plugins = [];
+
+    /** @var array Array of options to give to the plugin client */
+    private $options = [];
+
+    /**
+     * @param int $priority Priority of the plugin. The higher comes first.
+     */
+    public function addPlugin(Plugin $plugin, int $priority = 0): self
+    {
+        $this->plugins[$priority][] = $plugin;
+
+        return $this;
+    }
+
+    public function setOption(string $name, $value): self
+    {
+        $this->options[$name] = $value;
+
+        return $this;
+    }
+
+    public function removeOption(string $name): self
+    {
+        unset($this->options[$name]);
+
+        return $this;
+    }
+
+    /**
+     * @param ClientInterface | HttpAsyncClient $client
+     */
+    public function createClient($client): PluginClient
+    {
+        if (!$client instanceof ClientInterface && !$client instanceof HttpAsyncClient) {
+            throw new \RuntimeException('You must provide a valid http client');
+        }
+
+        $plugins = $this->plugins;
+
+        if (0 === count($plugins)) {
+            $plugins[] = [];
+        }
+
+        krsort($plugins);
+        $plugins = array_merge(...$plugins);
+
+        return new PluginClient(
+            $client,
+            array_values($plugins),
+            $this->options
+        );
+    }
+}

--- a/tests/PluginClientBuilderTest.php
+++ b/tests/PluginClientBuilderTest.php
@@ -49,6 +49,29 @@ class PluginClientBuilderTest extends TestCase
         $this->assertSame($expected, $plugged);
     }
 
+    /** @dataProvider clientProvider */
+    public function testOptions(string $client): void
+    {
+        $builder = new PluginClientBuilder();
+        $builder->setOption('max_restarts', 5);
+
+        $client = $this->prophesize($client)->reveal();
+        $client = $builder->createClient($client);
+
+        $closure = Closure::bind(
+            function (): array {
+                return $this->options;
+            },
+            $client,
+            PluginClient::class
+        );
+
+        $options = $closure();
+
+        $this->assertArrayHasKey('max_restarts', $options);
+        $this->assertSame(5, $options['max_restarts']);
+    }
+
     public function clientProvider(): iterable
     {
         yield 'sync\'d http client' => [HttpClient::class];

--- a/tests/PluginClientBuilderTest.php
+++ b/tests/PluginClientBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Http\Client\Common;
+
+use Closure;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
+use Http\Client\Common\PluginClientBuilder;
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use PHPUnit\Framework\TestCase;
+
+class PluginClientBuilderTest extends TestCase
+{
+    /** @dataProvider clientProvider */
+    public function testPriority(string $client): void
+    {
+        $builder = new PluginClientBuilder();
+
+        $plugins = [
+            10 => $this->prophesize(Plugin::class)->reveal(),
+            -10 => $this->prophesize(Plugin::class)->reveal(),
+            0 => $this->prophesize(Plugin::class)->reveal(),
+        ];
+
+        foreach ($plugins as $priority => $plugin) {
+            $builder->addPlugin($plugin, $priority);
+        }
+
+        $client = $this->prophesize($client)->reveal();
+        $client = $builder->createClient($client);
+
+        $closure = Closure::bind(
+            function (): array {
+                return $this->plugins;
+            },
+            $client,
+            PluginClient::class
+        );
+
+        $plugged = $closure();
+
+        $expected = $plugins;
+        krsort($expected);
+        $expected = array_values($expected);
+
+        $this->assertSame($expected, $plugged);
+    }
+
+    public function clientProvider(): iterable
+    {
+        yield 'sync\'d http client' => [HttpClient::class];
+        yield 'async\'d http client' => [HttpAsyncClient::class];
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #96 
| Documentation   | None, for now ?
| License         | MIT

#### What's in this PR?
This adds a plugin client builder, that allows to dynamically build a plugin client with plugins set on the go.

#### Why?
If you have some conditions on your plugin client (such as the auth can vary, some more headers can be dynamically added, ... like in the github's api from knp or my behat extension for http calls), it can be useful to not have a static plugin client with its plugin list, but to be able to add / remove them when needed.

As mentionned in the two repositories ([https://github.com/KnpLabs/php-github-api/blob/2.10.1/lib/Github/Client.php#L314-L331](Github's Client for the github php api of knp, or [my behat extension](https://github.com/Taluu/Behapi.git)), we both had to implement our own plugin builder, so this shows there's a "demand" for that.

We could have used the PluginClientFactory, but the problem with it is that when creating the client, we need to provide _all_ the plugins on the go, which is not (IMO) practical.

#### Example Usage

``` php
use Http\Client\Common\PluginClientBuilder;

// $client is a php-http client or a psr-18 one
// $plugin is a php-http plugin, pick one (auth basic, auth oauth, ... anything goes)

$builder = new PluginClientBuilder();
$builder->addPlugin($plugin); // by default, priority is 0

// do stuff....

$pluginClient = $builder->createClient($client);
// plugin client is a PluginClient with the `$plugin` plugin

// ...

$pluginClient = $otherBuilder->createClient($client);
// plugin client is another PluginClient and not the same as the one built previously
```

#### Checklist
- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

#### To Do
- [x] Discuss the mutability ? **decision** : remove it.
- [x] How should we handle options in the builder ? In the create client ? In the constructor ? If in the create client, if changed should it retrigger the client creation ? **decision** : Add setter and remover for options, and inject that into the plugin client.
- [x] Add priorities in the plugins
- [x] Remove naming plugins
- [x] Tests ? As I didn't see many of those, and I wanted to throw a poc for a builder first