### PR TITLE
[2.0] Added support for Symfony 5 and fixed incorrect version operators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php-http/httplug": "^2.0",
         "php-http/message-factory": "^1.0",
         "php-http/message": "^1.6",
-        "symfony/options-resolver": " ^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1"
+        "symfony/options-resolver": " ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0"
     },
     "require-dev": {
         "doctrine/instantiator": "^1.1",


### PR DESCRIPTION
The old version constraint was `^3.4.20 || ^4.0.15 || ^4.1.9 || ^4.2.1"`. This would allow 4.1.0 to be installed, but I suppose this was not intended.

---

Closes #174.