### PR TITLE
Add 7.4 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 - 7.1
 - 7.2
 - 7.3
+- 7.4
 
 matrix:
   fast_finish: true
@@ -33,7 +34,7 @@ jobs:
     env: TEST_COMMAND="./vendor/bin/phpunit" DEPENDENCIES="phpunit/phpunit:^7.5 nyholm/psr7:^1.0"
 
     # Latest dev release
-  - php: 7.3
+  - php: 7.4
     env: STABILITY="dev"
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "doctrine/instantiator": "^1.1",
         "guzzlehttp/psr7": "^1.4",
-        "phpspec/phpspec": "^5.1",
+        "phpspec/phpspec": "^5.1 || ^6.0",
         "phpspec/prophecy": "^1.8",
         "sebastian/comparator": "^3.0"
     },


### PR DESCRIPTION
PHP 7.4 released, and we need run tests for 7.4 too

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| Documentation   | no
| License         | MIT


PHP 7.4 released, and we need run tests for 7.4 too