### PR TITLE
adds phpunit as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,6 @@
         ]
     },
     "config": {
-        "platform": {
-            "php": "7.1.33"
-        },
         "sort-packages": true
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,10 @@
     "require-dev": {
         "doctrine/instantiator": "^1.1",
         "guzzlehttp/psr7": "^1.4",
+        "nyholm/psr7": "^1.2",
         "phpspec/phpspec": "^5.1 || ^6.0",
         "phpspec/prophecy": "^1.8",
+        "phpunit/phpunit": "^7.5",
         "sebastian/comparator": "^3.0"
     },
     "suggest": {
@@ -42,8 +44,20 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpspec run",
-        "test-ci": "vendor/bin/phpspec run -c phpspec.ci.yml"
+        "test": [
+            "vendor/bin/phpspec run",
+            "vendor/bin/phpunit"
+        ],
+        "test-ci": [
+            "vendor/bin/phpspec run -c phpspec.ci.yml",
+            "vendor/bin/phpunit"
+        ]
+    },
+    "config": {
+        "platform": {
+            "php": "7.1.33"
+        },
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/tests/Plugin/AddPathPluginTest.php
+++ b/tests/Plugin/AddPathPluginTest.php
@@ -4,8 +4,7 @@ namespace tests\Http\Client\Common\Plugin;
 
 use Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\AddPathPlugin;
-use Http\Client\Common\PluginClient;
-use Http\Client\HttpClient;
+use Http\Client\Promise\HttpFulfilledPromise;
 use Nyholm\Psr7\Request;
 use Nyholm\Psr7\Response;
 use Nyholm\Psr7\Uri;
@@ -24,7 +23,7 @@ class AddPathPluginTest extends TestCase
      */
     private $first;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->first = function () {};
         $this->plugin = new AddPathPlugin(new Uri('/api'));
@@ -34,16 +33,18 @@ class AddPathPluginTest extends TestCase
     {
         $verify = function (RequestInterface $request) {
             $this->assertEquals('https://example.com/api/foo', $request->getUri()->__toString());
+
+            return new HttpFulfilledPromise(new Response());
         };
 
-        $request = new Request('GET', 'https://example.com/foo', ['Content-Type'=>'text/html']);
+        $request = new Request('GET', 'https://example.com/foo', ['Content-Type' => 'text/html']);
         $this->plugin->handleRequest($request, $verify, $this->first);
 
         // Make a second call with the same $request object
         $this->plugin->handleRequest($request, $verify, $this->first);
 
         // Make a new call with a new object but same URL
-        $request = new Request('GET', 'https://example.com/foo', ['Content-Type'=>'text/plain']);
+        $request = new Request('GET', 'https://example.com/foo', ['Content-Type' => 'text/plain']);
         $this->plugin->handleRequest($request, $verify, $this->first);
     }
 
@@ -56,7 +57,11 @@ class AddPathPluginTest extends TestCase
             // Run the plugin again with the modified request
             $this->plugin->handleRequest($request, function (RequestInterface $request) {
                 $this->assertEquals('https://example.com/api/foo', $request->getUri()->__toString());
+
+                return new HttpFulfilledPromise(new Response());
             }, $this->first);
+
+            return new HttpFulfilledPromise(new Response());
         }, $this->first);
     }
 
@@ -65,11 +70,15 @@ class AddPathPluginTest extends TestCase
         $request = new Request('GET', 'https://example.com/foo');
         $this->plugin->handleRequest($request, function (RequestInterface $request) {
             $this->assertEquals('https://example.com/api/foo', $request->getUri()->__toString());
+
+            return new HttpFulfilledPromise(new Response());
         }, $this->first);
 
         $request = new Request('GET', 'https://example.com/bar');
         $this->plugin->handleRequest($request, function (RequestInterface $request) {
             $this->assertEquals('https://example.com/api/bar', $request->getUri()->__toString());
+
+            return new HttpFulfilledPromise(new Response());
         }, $this->first);
     }
 
@@ -77,6 +86,8 @@ class AddPathPluginTest extends TestCase
     {
         $verify = function (RequestInterface $request) {
             $this->assertEquals('https://example.com/api/foo', $request->getUri()->__toString());
+
+            return new HttpFulfilledPromise(new Response());
         };
 
         $request = new Request('GET', 'https://example.com/api/foo');


### PR DESCRIPTION
this pr adds missing phpunit dev dependencies, fixes existing tests and sets base php platform in composer to ensure only compatible dependencies

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fix #182 
| Documentation   | -
| License         | MIT


#### What's in this PR?

- adds required dev dependencies to composer.json to run existing phpunit tests
- fixes existing phpunit tests
- adds phpunit execution to composer test scripts
- adds base platform to composer.json to ensure only php 7.1 compatible dependencies getting added

#### Why?

Existing PHPUnit tests should get executed during CI runs.

#### Checklist

- [x] ~Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix~ (@dbu thinks: not needed for a testing setup change)

#### To Do

- [x] Need feedback if we could/should replace nyholm/psr7 dependencies/usage in tests with something else
- [x] Need feedback if setting the base platform in composer.json to ensure php 7.1 compatible  dependencies only is okay
