### PR TITLE
Memory leak hotfix

### DIFF
--- a/spec/BatchClientSpec.php
+++ b/spec/BatchClientSpec.php
@@ -2,14 +2,14 @@
 
 namespace spec\Http\Client\Common;
 
-use Http\Client\HttpClient;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
 use Http\Client\Common\BatchClient;
 use Http\Client\Common\BatchResult;
-use Http\Client\Exception\HttpException;
 use Http\Client\Common\Exception\BatchException;
+use Http\Client\Exception\HttpException;
+use Http\Client\HttpClient;
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class BatchClientSpec extends ObjectBehavior
 {

--- a/spec/BatchResultSpec.php
+++ b/spec/BatchResultSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\BatchResult;
 use Http\Client\Exception;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\BatchResult;
 
 class BatchResultSpec extends ObjectBehavior
 {

--- a/spec/EmulatedHttpAsyncClientSpec.php
+++ b/spec/EmulatedHttpAsyncClientSpec.php
@@ -2,15 +2,15 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\EmulatedHttpAsyncClient;
+use Http\Client\Exception\TransferException;
+use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\EmulatedHttpAsyncClient;
-use Http\Client\HttpAsyncClient;
-use Http\Client\Promise\HttpFulfilledPromise;
-use Http\Client\Exception\TransferException;
-use Http\Client\Promise\HttpRejectedPromise;
 
 class EmulatedHttpAsyncClientSpec extends ObjectBehavior
 {

--- a/spec/EmulatedHttpClientSpec.php
+++ b/spec/EmulatedHttpClientSpec.php
@@ -2,15 +2,15 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\EmulatedHttpClient;
+use Http\Client\Exception;
 use Http\Client\Exception\TransferException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\EmulatedHttpClient;
-use Http\Client\Exception;
 
 class EmulatedHttpClientSpec extends ObjectBehavior
 {

--- a/spec/Exception/BatchExceptionSpec.php
+++ b/spec/Exception/BatchExceptionSpec.php
@@ -3,9 +3,9 @@
 namespace spec\Http\Client\Common\Exception;
 
 use Http\Client\Common\BatchResult;
+use Http\Client\Common\Exception\BatchException;
 use Http\Client\Exception;
 use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Exception\BatchException;
 
 class BatchExceptionSpec extends ObjectBehavior
 {

--- a/spec/FlexibleHttpClientSpec.php
+++ b/spec/FlexibleHttpClientSpec.php
@@ -2,13 +2,13 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\FlexibleHttpClient;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\FlexibleHttpClient;
 
 class FlexibleHttpClientSpec extends ObjectBehavior
 {

--- a/spec/HttpClientPool/HttpClientPoolItemSpec.php
+++ b/spec/HttpClientPool/HttpClientPoolItemSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Http\Client\Common\HttpClientPool;
 
 use Http\Client\Exception;
+use Http\Client\Exception\RequestException;
 use Http\Client\Exception\TransferException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
@@ -12,7 +13,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Exception\RequestException;
 
 class HttpClientPoolItemSpec extends ObjectBehavior
 {

--- a/spec/HttpClientPool/LeastUsedClientPoolSpec.php
+++ b/spec/HttpClientPool/LeastUsedClientPoolSpec.php
@@ -2,7 +2,10 @@
 
 namespace spec\Http\Client\Common\HttpClientPool;
 
+use Http\Client\Common\Exception\HttpClientNotFoundException;
 use Http\Client\Common\HttpClientPool\HttpClientPoolItem;
+use Http\Client\Common\HttpClientPool\LeastUsedClientPool;
+use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
@@ -10,9 +13,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Common\HttpClientPool\LeastUsedClientPool;
-use Http\Client\Common\Exception\HttpClientNotFoundException;
-use Http\Client\Exception\HttpException;
 
 class LeastUsedClientPoolSpec extends ObjectBehavior
 {

--- a/spec/HttpClientPool/RandomClientPoolSpec.php
+++ b/spec/HttpClientPool/RandomClientPoolSpec.php
@@ -2,7 +2,10 @@
 
 namespace spec\Http\Client\Common\HttpClientPool;
 
+use Http\Client\Common\Exception\HttpClientNotFoundException;
 use Http\Client\Common\HttpClientPool\HttpClientPoolItem;
+use Http\Client\Common\HttpClientPool\RandomClientPool;
+use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
@@ -10,9 +13,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Common\HttpClientPool\RandomClientPool;
-use Http\Client\Common\Exception\HttpClientNotFoundException;
-use Http\Client\Exception\HttpException;
 
 class RandomClientPoolSpec extends ObjectBehavior
 {

--- a/spec/HttpClientPool/RoundRobinClientPoolSpec.php
+++ b/spec/HttpClientPool/RoundRobinClientPoolSpec.php
@@ -2,7 +2,10 @@
 
 namespace spec\Http\Client\Common\HttpClientPool;
 
+use Http\Client\Common\Exception\HttpClientNotFoundException;
 use Http\Client\Common\HttpClientPool\HttpClientPoolItem;
+use Http\Client\Common\HttpClientPool\RoundRobinClientPool;
+use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
@@ -10,9 +13,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Common\HttpClientPool\RoundRobinClientPool;
-use Http\Client\Common\Exception\HttpClientNotFoundException;
-use Http\Client\Exception\HttpException;
 
 class RoundRobinClientPoolSpec extends ObjectBehavior
 {

--- a/spec/HttpClientRouterSpec.php
+++ b/spec/HttpClientRouterSpec.php
@@ -4,14 +4,14 @@ namespace spec\Http\Client\Common;
 
 use Http\Client\Common\Exception\HttpClientNoMatchException;
 use Http\Client\Common\HttpClientRouter;
-use Http\Message\RequestMatcher;
+use Http\Client\Common\HttpClientRouterInterface;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Http\Message\RequestMatcher;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\HttpClientRouterInterface;
 
 class HttpClientRouterSpec extends ObjectBehavior
 {

--- a/spec/Plugin/AddHostPluginSpec.php
+++ b/spec/Plugin/AddHostPluginSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\AddHostPlugin;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Plugin\AddHostPlugin;
-use Http\Client\Common\Plugin;
 
 class AddHostPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/AddPathPluginSpec.php
+++ b/spec/Plugin/AddPathPluginSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\AddPathPlugin;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Plugin\AddPathPlugin;
-use Http\Client\Common\Plugin;
 
 class AddPathPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/AuthenticationPluginSpec.php
+++ b/spec/Plugin/AuthenticationPluginSpec.php
@@ -2,13 +2,13 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\AuthenticationPlugin;
 use Http\Message\Authentication;
 use Http\Promise\Promise;
-use Psr\Http\Message\RequestInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\AuthenticationPlugin;
-use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
 
 class AuthenticationPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/BaseUriPluginSpec.php
+++ b/spec/Plugin/BaseUriPluginSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\BaseUriPlugin;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Plugin\BaseUriPlugin;
-use Http\Client\Common\Plugin;
 
 class BaseUriPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/ContentLengthPluginSpec.php
+++ b/spec/Plugin/ContentLengthPluginSpec.php
@@ -2,13 +2,13 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\ContentLengthPlugin;
 use PhpSpec\Exception\Example\SkippingException;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\StreamInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\ContentLengthPlugin;
-use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
 
 class ContentLengthPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/CookiePluginSpec.php
+++ b/spec/Plugin/CookiePluginSpec.php
@@ -2,18 +2,18 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\CookiePlugin;
+use Http\Client\Exception\TransferException;
 use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
 use Http\Message\Cookie;
 use Http\Message\CookieJar;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Plugin\CookiePlugin;
-use Http\Client\Common\Plugin;
-use Http\Client\Promise\HttpRejectedPromise;
-use Http\Client\Exception\TransferException;
 
 class CookiePluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/DecoderPluginSpec.php
+++ b/spec/Plugin/DecoderPluginSpec.php
@@ -2,17 +2,17 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\DecoderPlugin;
 use Http\Client\Promise\HttpFulfilledPromise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamInterface;
+use Http\Message\Encoding\DecompressStream;
+use Http\Message\Encoding\GzipDecodeStream;
 use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\DecoderPlugin;
-use Http\Client\Common\Plugin;
-use Http\Message\Encoding\GzipDecodeStream;
-use Http\Message\Encoding\DecompressStream;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class DecoderPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/ErrorPluginSpec.php
+++ b/spec/Plugin/ErrorPluginSpec.php
@@ -2,16 +2,16 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
-use Http\Client\Promise\HttpFulfilledPromise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Http\Client\Common\Plugin\ErrorPlugin;
-use Http\Client\Common\Plugin;
-use Http\Client\Promise\HttpRejectedPromise;
 use Http\Client\Common\Exception\ClientErrorException;
 use Http\Client\Common\Exception\ServerErrorException;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\ErrorPlugin;
+use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class ErrorPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/HistoryPluginSpec.php
+++ b/spec/Plugin/HistoryPluginSpec.php
@@ -2,15 +2,15 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
-use Http\Client\Exception\TransferException;
+use Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\Journal;
+use Http\Client\Exception\TransferException;
 use Http\Client\Promise\HttpFulfilledPromise;
 use Http\Client\Promise\HttpRejectedPromise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class HistoryPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/QueryDefaultsPluginSpec.php
+++ b/spec/Plugin/QueryDefaultsPluginSpec.php
@@ -3,10 +3,10 @@
 namespace spec\Http\Client\Common\Plugin;
 
 use Http\Client\Common\Plugin;
-use Psr\Http\Message\RequestInterface;
-use PhpSpec\ObjectBehavior;
-use Psr\Http\Message\UriInterface;
 use Http\Client\Common\Plugin\QueryDefaultsPlugin;
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
 
 class QueryDefaultsPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/RequestMatcherPluginSpec.php
+++ b/spec/Plugin/RequestMatcherPluginSpec.php
@@ -3,12 +3,12 @@
 namespace spec\Http\Client\Common\Plugin;
 
 use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\RequestMatcherPlugin;
 use Http\Message\RequestMatcher;
 use Http\Promise\Promise;
-use Psr\Http\Message\RequestInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\RequestMatcherPlugin;
+use Psr\Http\Message\RequestInterface;
 
 class RequestMatcherPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/RetryPluginSpec.php
+++ b/spec/Plugin/RetryPluginSpec.php
@@ -2,15 +2,15 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\RetryPlugin;
 use Http\Client\Exception;
 use Http\Client\Promise\HttpFulfilledPromise;
 use Http\Client\Promise\HttpRejectedPromise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\RetryPlugin;
-use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class RetryPluginSpec extends ObjectBehavior
 {

--- a/spec/PluginClientFactorySpec.php
+++ b/spec/PluginClientFactorySpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\PluginClient;
+use Http\Client\Common\PluginClientFactory;
 use Http\Client\HttpClient;
 use PhpSpec\ObjectBehavior;
-use Http\Client\Common\PluginClientFactory;
-use Http\Client\Common\PluginClient;
 
 class PluginClientFactorySpec extends ObjectBehavior
 {

--- a/spec/PluginClientSpec.php
+++ b/spec/PluginClientSpec.php
@@ -2,16 +2,16 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\Exception\LoopException;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
-use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Exception\LoopException;
-use Http\Client\Common\PluginClient;
 
 class PluginClientSpec extends ObjectBehavior
 {

--- a/src/BatchResult.php
+++ b/src/BatchResult.php
@@ -66,7 +66,6 @@ final class BatchResult
     /**
      * Returns the response for a successful request.
      *
-     *
      * @throws \UnexpectedValueException If request was not part of the batch or failed
      */
     public function getResponseFor(RequestInterface $request): ResponseInterface
@@ -125,7 +124,6 @@ final class BatchResult
 
     /**
      * Returns the exception for a failed request.
-     *
      *
      * @throws \UnexpectedValueException If request was not part of the batch or was successful
      */

--- a/src/Exception/BatchException.php
+++ b/src/Exception/BatchException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Http\Client\Common\Exception;
 
-use Http\Client\Exception\TransferException;
 use Http\Client\Common\BatchResult;
+use Http\Client\Exception\TransferException;
 
 /**
  * This exception is thrown when HttpClient::sendRequests led to at least one failure.

--- a/src/HttpClientPool/HttpClientPoolItem.php
+++ b/src/HttpClientPool/HttpClientPoolItem.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Http\Client\Common\HttpClientPool;
 
 use Http\Client\Common\FlexibleHttpClient;
+use Http\Client\Exception;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
-use Http\Client\Exception;
 use Psr\Http\Message\ResponseInterface;
 
 /**

--- a/src/Plugin/CookiePlugin.php
+++ b/src/Plugin/CookiePlugin.php
@@ -119,15 +119,7 @@ final class CookiePlugin implements Plugin
                     try {
                         $expires = CookieUtil::parseDate($value);
                     } catch (UnexpectedValueException $e) {
-                        throw new TransferException(
-                            sprintf(
-                                'Cookie header `%s` expires value `%s` could not be converted to date',
-                                $name,
-                                $value
-                            ),
-                            0,
-                            $e
-                        );
+                        throw new TransferException(sprintf('Cookie header `%s` expires value `%s` could not be converted to date', $name, $value), 0, $e);
                     }
 
                     break;

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -25,11 +25,11 @@ final class PluginChain
     /**
      * @param Plugin[] $plugins
      */
-    public function __construct(array $plugins, callable $clientCallable, int $maxRestarts)
+    public function __construct(array $plugins, callable $clientCallable, array $options = [])
     {
         $this->plugins = $plugins;
         $this->clientCallable = $clientCallable;
-        $this->maxRestarts = $maxRestarts;
+        $this->maxRestarts = (int) ($options['max_restarts'] ?? 0);
     }
 
     private function createChain(): callable

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Http\Client\Common;
 
+use function array_reverse;
 use Http\Client\Common\Exception\LoopException;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
-use function array_reverse;
 
 final class PluginChain
 {

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -24,8 +24,6 @@ final class PluginChain
 
     /**
      * @param Plugin[] $plugins
-     * @param callable $clientCallable
-     * @param int $maxRestarts
      */
     public function __construct(array $plugins, callable $clientCallable, int $maxRestarts)
     {

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -7,6 +7,7 @@ namespace Http\Client\Common;
 use Http\Client\Common\Exception\LoopException;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
+use function array_reverse;
 
 final class PluginChain
 {
@@ -35,8 +36,9 @@ final class PluginChain
     private function createChain(): callable
     {
         $lastCallable = $this->clientCallable;
+        $reversedPlugins = array_reverse($this->plugins);
 
-        foreach ($this->plugins as $plugin) {
+        foreach ($reversedPlugins as $plugin) {
             $lastCallable = function (RequestInterface $request) use ($plugin, $lastCallable) {
                 return $plugin->handleRequest($request, $lastCallable, $this);
             };

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Client\Common;
+
+use Http\Client\Common\Exception\LoopException;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+
+final class PluginChain
+{
+    /** @var Plugin[] */
+    private $plugins;
+
+    /** @var callable */
+    private $clientCallable;
+
+    /** @var int */
+    private $maxRestarts;
+
+    /** @var int */
+    private $restarts = 0;
+
+    /**
+     * @param Plugin[] $plugins
+     * @param callable $clientCallable
+     * @param int $maxRestarts
+     */
+    public function __construct(array $plugins, callable $clientCallable, int $maxRestarts)
+    {
+        $this->plugins = $plugins;
+        $this->clientCallable = $clientCallable;
+        $this->maxRestarts = $maxRestarts;
+    }
+
+    private function createChain(): callable
+    {
+        $lastCallable = $this->clientCallable;
+
+        foreach ($this->plugins as $plugin) {
+            $lastCallable = function (RequestInterface $request) use ($plugin, $lastCallable) {
+                return $plugin->handleRequest($request, $lastCallable, $this);
+            };
+        }
+
+        return $lastCallable;
+    }
+
+    public function __invoke(RequestInterface $request): Promise
+    {
+        if ($this->restarts > $this->maxRestarts) {
+            throw new LoopException('Too many restarts in plugin client', $request);
+        }
+
+        ++$this->restarts;
+
+        return $this->createChain()($request);
+    }
+}

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Http\Client\Common;
 
-use Http\Client\Common\Exception\LoopException;
 use Http\Client\Exception as HttplugException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -124,6 +124,6 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      */
     private function createPluginChain(array $pluginList, callable $clientCallable): callable
     {
-        return new PluginChain($pluginList, $clientCallable, $this->options['max_restarts']);
+        return new PluginChain($pluginList, $clientCallable, $this->options);
     }
 }

--- a/tests/PluginChainTest.php
+++ b/tests/PluginChainTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Http\Client\Common;
+
+use Http\Client\Common\Exception\LoopException;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginChain;
+use Http\Promise\Promise;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+
+class PluginChainTest extends TestCase
+{
+    private function createPlugin(callable $func): Plugin
+    {
+        return new class ($func) implements Plugin
+        {
+            public $func;
+
+            public function __construct(callable $func)
+            {
+                $this->func = $func;
+            }
+
+            public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+            {
+                ($this->func)($request, $next, $first);
+
+                return $next($request);
+            }
+        };
+    }
+
+    public function testChainShouldInvokePluginsInReversedOrder(): void
+    {
+        $pluginOrderCalls = [];
+
+        $plugin1 = $this->createPlugin(static function () use (&$pluginOrderCalls) {
+            $pluginOrderCalls[] = 'plugin1';
+        });
+        $plugin2 = $this->createPlugin(static function () use (&$pluginOrderCalls) {
+            $pluginOrderCalls[] = 'plugin2';
+        });
+
+        $request = $this->prophesize(RequestInterface::class);
+        $responsePromise = $this->prophesize(Promise::class);
+
+        $clientCallable = static function () use ($responsePromise) {
+            return $responsePromise->reveal();
+        };
+
+        $pluginOrderCalls = [];
+
+        $plugins = [
+            $plugin1,
+            $plugin2,
+        ];
+
+        $pluginChain = new PluginChain($plugins, $clientCallable);
+
+        $result = $pluginChain($request->reveal());
+
+        $this->assertSame($responsePromise->reveal(), $result);
+        $this->assertSame(['plugin1', 'plugin2'], $pluginOrderCalls);
+    }
+
+    public function testShouldThrowLoopExceptionOnMaxRestarts(): void
+    {
+        $this->expectException(LoopException::class);
+
+        $request = $this->prophesize(RequestInterface::class);
+        $responsePromise = $this->prophesize(Promise::class);
+        $calls = 0;
+        $clientCallable = static function () use ($responsePromise, &$calls) {
+            ++$calls;
+
+            return $responsePromise->reveal();
+        };
+
+        $pluginChain = new PluginChain([], $clientCallable, ['max_restarts' => 2]);
+
+        $pluginChain($request->reveal());
+        $this->assertSame(1, $calls);
+        $pluginChain($request->reveal());
+        $this->assertSame(2, $calls);
+        $pluginChain($request->reveal());
+        $this->assertSame(3, $calls);
+        $pluginChain($request->reveal());
+    }
+}


### PR DESCRIPTION
Hi,
there is a big memory leak when using the `PluginClient` with plugins.

Example code to reproduce the issue:

```php
use Http\Client\Curl\Client;

$samples = 50;
$curlClient = new Client();
$requestFactory = $container->get(\Psr\Http\Message\RequestFactoryInterface::class);
$pluginClient = new \Http\Client\Common\PluginClient(
    $curlClient,
    [
        new \Http\Client\Common\Plugin\RedirectPlugin(),
    ]
);

$request = $requestFactory->createRequest('GET', 'https://google.it');
for ($i = 1; $i <= $samples; $i++) {
    $pluginClient->sendRequest($request);
    echo 'memory: ' . memory_get_usage() . PHP_EOL;
    // gc_collect_cycles(); without this, gc isn't able to free memory
}
```

This PR fixes it removing useless variable reference.