### PR TITLE
allow symfony/options-resolver:^2.6 as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php-http/httplug": "^2.0",
         "php-http/message-factory": "^1.0",
         "php-http/message": "^1.6",
-        "symfony/options-resolver": " ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0"
+        "symfony/options-resolver": "^2.6 || ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0"
     },
     "require-dev": {
         "doctrine/instantiator": "^1.1",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Allow lower version of symfony/options-resolver

#### Why?

Hello, I'm working at Blablacar and our PHP monolith is still running on Symfony 2.8.x.

We are working pieces by pieces on migrating to 3.x but believe me it is not an easy task.

In the meantime, not allowing options-resolver 2.x prevent us from integrating a various numbers of internal php sdk that are already using httplug 2.x abstraction.

Therefore I was was wondering if there was a specific reason for preventing the use of options-resolver 2.x and removing it in httplug 2.x (it was previously authorised in httplug 1.x)?

There is no incompatibility issue ([CHANGELOG](https://github.com/symfony/options-resolver/blob/master/CHANGELOG.md)) preventing its use.

Thanks.

