### PR TITLE
Upgrade to friends-of-phpspec/phpspec-code-coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
   - php: 7.1
     env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
   - php: 7.2
-    env: COVERAGE=true DEPENDENCIES="leanphp/phpspec-code-coverage phpspec/phpspec:^4.2"
+    env: COVERAGE=true DEPENDENCIES="friends-of-phpspec/phpspec-code-coverage phpspec/phpspec:^4.2"
     script:
     - composer test-ci
     after_success:

--- a/phpspec.ci.yml
+++ b/phpspec.ci.yml
@@ -4,7 +4,7 @@ suites:
         psr4_prefix: Http\Client\Common
 formatter.name: pretty
 extensions:
-    LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
+    FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension: ~
 code_coverage:
     format: clover
     output: build/coverage.xml


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #181
| Documentation   | –
| License         | MIT

#### Why?

Since `leanphp/phpspec-code-coverage` is abandoned, we should switch to `friends-of-phpspec/phpspec-code-coverage`.

#### Checklist

- <s>[ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix</s>
- <s>[ ] Documentation pull request created (if not simply a bugfix)</s>

#### Note

I noticed that `phpspec/phpspec:^4.2` is required in `.travis.yml`, while `phpspec/phpspec": "^5.1 || ^6.0` is required in composer.json. Perhaps they should be aligned?