### PR TITLE
Support the PSR17 request factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,10 @@
         "php-http/httplug": "^2.0",
         "php-http/message-factory": "^1.0",
         "php-http/message": "^1.6",
-        "symfony/options-resolver": "^2.6 || ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0"
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0",
+        "symfony/options-resolver": "^2.6 || ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0",
+        "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {
         "doctrine/instantiator": "^1.1",

--- a/src/HttpMethodsClient.php
+++ b/src/HttpMethodsClient.php
@@ -6,6 +6,7 @@ namespace Http\Client\Common;
 
 use Http\Message\RequestFactory;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -17,12 +18,21 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
     private $httpClient;
 
     /**
-     * @var RequestFactory
+     * @var RequestFactory|RequestFactoryInterface
      */
     private $requestFactory;
 
-    public function __construct(ClientInterface $httpClient, RequestFactory $requestFactory)
+    /**
+     * @param RequestFactory|RequestFactoryInterface
+     */
+    public function __construct(ClientInterface $httpClient, $requestFactory)
     {
+        if (!$requestFactory instanceof RequestFactory && !$requestFactory instanceof RequestFactoryInterface) {
+            throw new \TypeError(
+                sprintf('%s::__construct(): Argument #2 ($requestFactory) must be of type %s|%s, %s given', self::class, RequestFactory::class, RequestFactoryInterface::class, get_debug_type($requestFactory))
+            );
+        }
+
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

`Http\Discovery\MessageFactoryDiscovery`  is deprecated, so there is no way to discover a `Http\Message\RequestFactory` instance using non-deprecated APIs. `Http\Client\Common\HttpMethodsClient` should therefore except a PSR17 request factory `Psr\Http\Message\RequestFactoryInterface` as well as a `Http\Message\RequestFactory`.