### PR TITLE
fix cs config

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -19,5 +19,6 @@ return PhpCsFixer\Config::create()
         ],
         'no_empty_phpdoc' => true,
         'no_superfluous_phpdoc_tags' => true,
+        'single_line_throw' => false,
     ])
     ->setFinder($finder);

--- a/spec/BatchClientSpec.php
+++ b/spec/BatchClientSpec.php
@@ -2,14 +2,14 @@
 
 namespace spec\Http\Client\Common;
 
-use Http\Client\HttpClient;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
 use Http\Client\Common\BatchClient;
 use Http\Client\Common\BatchResult;
-use Http\Client\Exception\HttpException;
 use Http\Client\Common\Exception\BatchException;
+use Http\Client\Exception\HttpException;
+use Http\Client\HttpClient;
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class BatchClientSpec extends ObjectBehavior
 {

--- a/spec/BatchResultSpec.php
+++ b/spec/BatchResultSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\BatchResult;
 use Http\Client\Exception;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\BatchResult;
 
 class BatchResultSpec extends ObjectBehavior
 {

--- a/spec/EmulatedHttpAsyncClientSpec.php
+++ b/spec/EmulatedHttpAsyncClientSpec.php
@@ -2,15 +2,15 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\EmulatedHttpAsyncClient;
+use Http\Client\Exception\TransferException;
+use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\EmulatedHttpAsyncClient;
-use Http\Client\HttpAsyncClient;
-use Http\Client\Promise\HttpFulfilledPromise;
-use Http\Client\Exception\TransferException;
-use Http\Client\Promise\HttpRejectedPromise;
 
 class EmulatedHttpAsyncClientSpec extends ObjectBehavior
 {

--- a/spec/EmulatedHttpClientSpec.php
+++ b/spec/EmulatedHttpClientSpec.php
@@ -2,15 +2,15 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\EmulatedHttpClient;
+use Http\Client\Exception;
 use Http\Client\Exception\TransferException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\EmulatedHttpClient;
-use Http\Client\Exception;
 
 class EmulatedHttpClientSpec extends ObjectBehavior
 {

--- a/spec/Exception/BatchExceptionSpec.php
+++ b/spec/Exception/BatchExceptionSpec.php
@@ -3,9 +3,9 @@
 namespace spec\Http\Client\Common\Exception;
 
 use Http\Client\Common\BatchResult;
+use Http\Client\Common\Exception\BatchException;
 use Http\Client\Exception;
 use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Exception\BatchException;
 
 class BatchExceptionSpec extends ObjectBehavior
 {

--- a/spec/FlexibleHttpClientSpec.php
+++ b/spec/FlexibleHttpClientSpec.php
@@ -2,13 +2,13 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\FlexibleHttpClient;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\FlexibleHttpClient;
 
 class FlexibleHttpClientSpec extends ObjectBehavior
 {

--- a/spec/HttpClientPool/HttpClientPoolItemSpec.php
+++ b/spec/HttpClientPool/HttpClientPoolItemSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Http\Client\Common\HttpClientPool;
 
 use Http\Client\Exception;
+use Http\Client\Exception\RequestException;
 use Http\Client\Exception\TransferException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
@@ -12,7 +13,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Exception\RequestException;
 
 class HttpClientPoolItemSpec extends ObjectBehavior
 {

--- a/spec/HttpClientPool/LeastUsedClientPoolSpec.php
+++ b/spec/HttpClientPool/LeastUsedClientPoolSpec.php
@@ -2,7 +2,10 @@
 
 namespace spec\Http\Client\Common\HttpClientPool;
 
+use Http\Client\Common\Exception\HttpClientNotFoundException;
 use Http\Client\Common\HttpClientPool\HttpClientPoolItem;
+use Http\Client\Common\HttpClientPool\LeastUsedClientPool;
+use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
@@ -10,9 +13,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Common\HttpClientPool\LeastUsedClientPool;
-use Http\Client\Common\Exception\HttpClientNotFoundException;
-use Http\Client\Exception\HttpException;
 
 class LeastUsedClientPoolSpec extends ObjectBehavior
 {

--- a/spec/HttpClientPool/RandomClientPoolSpec.php
+++ b/spec/HttpClientPool/RandomClientPoolSpec.php
@@ -2,7 +2,10 @@
 
 namespace spec\Http\Client\Common\HttpClientPool;
 
+use Http\Client\Common\Exception\HttpClientNotFoundException;
 use Http\Client\Common\HttpClientPool\HttpClientPoolItem;
+use Http\Client\Common\HttpClientPool\RandomClientPool;
+use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
@@ -10,9 +13,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Common\HttpClientPool\RandomClientPool;
-use Http\Client\Common\Exception\HttpClientNotFoundException;
-use Http\Client\Exception\HttpException;
 
 class RandomClientPoolSpec extends ObjectBehavior
 {

--- a/spec/HttpClientPool/RoundRobinClientPoolSpec.php
+++ b/spec/HttpClientPool/RoundRobinClientPoolSpec.php
@@ -2,7 +2,10 @@
 
 namespace spec\Http\Client\Common\HttpClientPool;
 
+use Http\Client\Common\Exception\HttpClientNotFoundException;
 use Http\Client\Common\HttpClientPool\HttpClientPoolItem;
+use Http\Client\Common\HttpClientPool\RoundRobinClientPool;
+use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Http\Promise\Promise;
@@ -10,9 +13,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Http\Client\Common\HttpClientPool\RoundRobinClientPool;
-use Http\Client\Common\Exception\HttpClientNotFoundException;
-use Http\Client\Exception\HttpException;
 
 class RoundRobinClientPoolSpec extends ObjectBehavior
 {

--- a/spec/HttpClientRouterSpec.php
+++ b/spec/HttpClientRouterSpec.php
@@ -4,14 +4,14 @@ namespace spec\Http\Client\Common;
 
 use Http\Client\Common\Exception\HttpClientNoMatchException;
 use Http\Client\Common\HttpClientRouter;
-use Http\Message\RequestMatcher;
+use Http\Client\Common\HttpClientRouterInterface;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Http\Message\RequestMatcher;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\HttpClientRouterInterface;
 
 class HttpClientRouterSpec extends ObjectBehavior
 {

--- a/spec/Plugin/AddHostPluginSpec.php
+++ b/spec/Plugin/AddHostPluginSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\AddHostPlugin;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Plugin\AddHostPlugin;
-use Http\Client\Common\Plugin;
 
 class AddHostPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/AddPathPluginSpec.php
+++ b/spec/Plugin/AddPathPluginSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\AddPathPlugin;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Plugin\AddPathPlugin;
-use Http\Client\Common\Plugin;
 
 class AddPathPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/AuthenticationPluginSpec.php
+++ b/spec/Plugin/AuthenticationPluginSpec.php
@@ -2,13 +2,13 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\AuthenticationPlugin;
 use Http\Message\Authentication;
 use Http\Promise\Promise;
-use Psr\Http\Message\RequestInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\AuthenticationPlugin;
-use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
 
 class AuthenticationPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/BaseUriPluginSpec.php
+++ b/spec/Plugin/BaseUriPluginSpec.php
@@ -2,11 +2,11 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\BaseUriPlugin;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Plugin\BaseUriPlugin;
-use Http\Client\Common\Plugin;
 
 class BaseUriPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/ContentLengthPluginSpec.php
+++ b/spec/Plugin/ContentLengthPluginSpec.php
@@ -2,13 +2,13 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\ContentLengthPlugin;
 use PhpSpec\Exception\Example\SkippingException;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\StreamInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\ContentLengthPlugin;
-use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
 
 class ContentLengthPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/CookiePluginSpec.php
+++ b/spec/Plugin/CookiePluginSpec.php
@@ -2,18 +2,18 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\CookiePlugin;
+use Http\Client\Exception\TransferException;
 use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
 use Http\Message\Cookie;
 use Http\Message\CookieJar;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Plugin\CookiePlugin;
-use Http\Client\Common\Plugin;
-use Http\Client\Promise\HttpRejectedPromise;
-use Http\Client\Exception\TransferException;
 
 class CookiePluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/DecoderPluginSpec.php
+++ b/spec/Plugin/DecoderPluginSpec.php
@@ -2,17 +2,17 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\DecoderPlugin;
 use Http\Client\Promise\HttpFulfilledPromise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamInterface;
+use Http\Message\Encoding\DecompressStream;
+use Http\Message\Encoding\GzipDecodeStream;
 use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\DecoderPlugin;
-use Http\Client\Common\Plugin;
-use Http\Message\Encoding\GzipDecodeStream;
-use Http\Message\Encoding\DecompressStream;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class DecoderPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/ErrorPluginSpec.php
+++ b/spec/Plugin/ErrorPluginSpec.php
@@ -2,16 +2,16 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
-use Http\Client\Promise\HttpFulfilledPromise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Http\Client\Common\Plugin\ErrorPlugin;
-use Http\Client\Common\Plugin;
-use Http\Client\Promise\HttpRejectedPromise;
 use Http\Client\Common\Exception\ClientErrorException;
 use Http\Client\Common\Exception\ServerErrorException;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\ErrorPlugin;
+use Http\Client\Promise\HttpFulfilledPromise;
+use Http\Client\Promise\HttpRejectedPromise;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class ErrorPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/HistoryPluginSpec.php
+++ b/spec/Plugin/HistoryPluginSpec.php
@@ -2,15 +2,15 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
-use Http\Client\Exception\TransferException;
+use Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\Journal;
+use Http\Client\Exception\TransferException;
 use Http\Client\Promise\HttpFulfilledPromise;
 use Http\Client\Promise\HttpRejectedPromise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class HistoryPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/QueryDefaultsPluginSpec.php
+++ b/spec/Plugin/QueryDefaultsPluginSpec.php
@@ -3,10 +3,10 @@
 namespace spec\Http\Client\Common\Plugin;
 
 use Http\Client\Common\Plugin;
-use Psr\Http\Message\RequestInterface;
-use PhpSpec\ObjectBehavior;
-use Psr\Http\Message\UriInterface;
 use Http\Client\Common\Plugin\QueryDefaultsPlugin;
+use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
 
 class QueryDefaultsPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/RequestMatcherPluginSpec.php
+++ b/spec/Plugin/RequestMatcherPluginSpec.php
@@ -3,12 +3,12 @@
 namespace spec\Http\Client\Common\Plugin;
 
 use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\RequestMatcherPlugin;
 use Http\Message\RequestMatcher;
 use Http\Promise\Promise;
-use Psr\Http\Message\RequestInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\RequestMatcherPlugin;
+use Psr\Http\Message\RequestInterface;
 
 class RequestMatcherPluginSpec extends ObjectBehavior
 {

--- a/spec/Plugin/RetryPluginSpec.php
+++ b/spec/Plugin/RetryPluginSpec.php
@@ -2,15 +2,15 @@
 
 namespace spec\Http\Client\Common\Plugin;
 
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\RetryPlugin;
 use Http\Client\Exception;
 use Http\Client\Promise\HttpFulfilledPromise;
 use Http\Client\Promise\HttpRejectedPromise;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Http\Client\Common\Plugin\RetryPlugin;
-use Http\Client\Common\Plugin;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class RetryPluginSpec extends ObjectBehavior
 {

--- a/spec/PluginClientFactorySpec.php
+++ b/spec/PluginClientFactorySpec.php
@@ -2,10 +2,10 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\PluginClient;
+use Http\Client\Common\PluginClientFactory;
 use Http\Client\HttpClient;
 use PhpSpec\ObjectBehavior;
-use Http\Client\Common\PluginClientFactory;
-use Http\Client\Common\PluginClient;
 
 class PluginClientFactorySpec extends ObjectBehavior
 {

--- a/spec/PluginClientSpec.php
+++ b/spec/PluginClientSpec.php
@@ -2,16 +2,16 @@
 
 namespace spec\Http\Client\Common;
 
+use Http\Client\Common\Exception\LoopException;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginClient;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
-use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use PhpSpec\ObjectBehavior;
-use Http\Client\Common\Exception\LoopException;
-use Http\Client\Common\PluginClient;
 
 class PluginClientSpec extends ObjectBehavior
 {

--- a/src/BatchResult.php
+++ b/src/BatchResult.php
@@ -66,7 +66,6 @@ final class BatchResult
     /**
      * Returns the response for a successful request.
      *
-     *
      * @throws \UnexpectedValueException If request was not part of the batch or failed
      */
     public function getResponseFor(RequestInterface $request): ResponseInterface
@@ -125,7 +124,6 @@ final class BatchResult
 
     /**
      * Returns the exception for a failed request.
-     *
      *
      * @throws \UnexpectedValueException If request was not part of the batch or was successful
      */

--- a/src/Exception/BatchException.php
+++ b/src/Exception/BatchException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Http\Client\Common\Exception;
 
-use Http\Client\Exception\TransferException;
 use Http\Client\Common\BatchResult;
+use Http\Client\Exception\TransferException;
 
 /**
  * This exception is thrown when HttpClient::sendRequests led to at least one failure.

--- a/src/HttpClientPool/HttpClientPoolItem.php
+++ b/src/HttpClientPool/HttpClientPoolItem.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Http\Client\Common\HttpClientPool;
 
 use Http\Client\Common\FlexibleHttpClient;
+use Http\Client\Exception;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
-use Http\Client\Exception;
 use Psr\Http\Message\ResponseInterface;
 
 /**


### PR DESCRIPTION
symfony settings added a new default setting to force exceptions on one line. this breaks ci because we do have longer exceptions.