### PR TITLE
Consitent implementation of union type checking

### DIFF
--- a/spec/FlexibleHttpClientSpec.php
+++ b/spec/FlexibleHttpClientSpec.php
@@ -32,11 +32,11 @@ class FlexibleHttpClientSpec extends ObjectBehavior
         $this->shouldImplement(HttpAsyncClient::class);
     }
 
-    public function it_throw_exception_if_invalid_client()
+    public function it_throw_type_error_if_invalid_client()
     {
         $this->beConstructedWith(null);
 
-        $this->shouldThrow(\LogicException::class)->duringInstantiation();
+        $this->shouldThrow(\TypeError::class)->duringInstantiation();
     }
 
     public function it_emulates_an_async_client(

--- a/src/FlexibleHttpClient.php
+++ b/src/FlexibleHttpClient.php
@@ -24,8 +24,10 @@ final class FlexibleHttpClient implements HttpClient, HttpAsyncClient
      */
     public function __construct($client)
     {
-        if (!($client instanceof ClientInterface) && !($client instanceof HttpAsyncClient)) {
-            throw new \LogicException(sprintf('Client must be an instance of %s or %s', ClientInterface::class, HttpAsyncClient::class));
+        if (!$client instanceof ClientInterface && !$client instanceof HttpAsyncClient) {
+            throw new \TypeError(
+                sprintf('%s::__construct(): Argument #1 ($client) must be of type %s|%s, %s given', self::class, ClientInterface::class, HttpAsyncClient::class, get_debug_type($client))
+            );
         }
 
         $this->httpClient = $client;

--- a/src/HttpClientPool/HttpClientPool.php
+++ b/src/HttpClientPool/HttpClientPool.php
@@ -29,6 +29,12 @@ abstract class HttpClientPool implements HttpClientPoolInterface
      */
     public function addHttpClient($client): void
     {
+        if (!$client instanceof ClientInterface && !$client instanceof HttpAsyncClient && !$client instanceof HttpClientPoolItem) {
+            throw new \TypeError(
+                sprintf('%s::addHttpClient(): Argument #1 ($client) must be of type %s|%s|%s, %s given', self::class, ClientInterface::class, HttpAsyncClient::class, HttpClientPoolItem::class, get_debug_type($client))
+            );
+        }
+
         if (!$client instanceof HttpClientPoolItem) {
             $client = new HttpClientPoolItem($client);
         }

--- a/src/HttpClientPool/HttpClientPoolItem.php
+++ b/src/HttpClientPool/HttpClientPoolItem.php
@@ -59,6 +59,12 @@ class HttpClientPoolItem implements HttpClient, HttpAsyncClient
      */
     public function __construct($client, int $reenableAfter = null)
     {
+        if (!$client instanceof ClientInterface && !$client instanceof HttpAsyncClient) {
+            throw new \TypeError(
+                sprintf('%s::__construct(): Argument #1 ($client) must be of type %s|%s, %s given', self::class, ClientInterface::class, HttpAsyncClient::class, get_debug_type($client))
+            );
+        }
+
         $this->client = new FlexibleHttpClient($client);
         $this->reenableAfter = $reenableAfter;
     }

--- a/src/HttpClientRouter.php
+++ b/src/HttpClientRouter.php
@@ -46,6 +46,12 @@ final class HttpClientRouter implements HttpClientRouterInterface
      */
     public function addClient($client, RequestMatcher $requestMatcher): void
     {
+        if (!$client instanceof ClientInterface && !$client instanceof HttpAsyncClient) {
+            throw new \TypeError(
+                sprintf('%s::addClient(): Argument #1 ($client) must be of type %s|%s, %s given', self::class, ClientInterface::class, HttpAsyncClient::class, get_debug_type($client))
+            );
+        }
+
         $this->clients[] = [
             'matcher' => $requestMatcher,
             'client' => new FlexibleHttpClient($client),

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -50,8 +50,6 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      *
      *     @var int      $max_restarts
      * }
-     *
-     * @throws \RuntimeException if client is not an instance of HttpClient or HttpAsyncClient
      */
     public function __construct($client, array $plugins = [], array $options = [])
     {
@@ -60,7 +58,9 @@ final class PluginClient implements HttpClient, HttpAsyncClient
         } elseif ($client instanceof ClientInterface) {
             $this->client = new EmulatedHttpAsyncClient($client);
         } else {
-            throw new \LogicException(sprintf('Client must be an instance of %s or %s', ClientInterface::class, HttpAsyncClient::class));
+            throw new \TypeError(
+                sprintf('%s::__construct(): Argument #1 ($client) must be of type %s|%s, %s given', self::class, ClientInterface::class, HttpAsyncClient::class, get_debug_type($client))
+            );
         }
 
         $this->plugins = $plugins;

--- a/src/PluginClientBuilder.php
+++ b/src/PluginClientBuilder.php
@@ -45,12 +45,14 @@ final class PluginClientBuilder
     }
 
     /**
-     * @param ClientInterface | HttpAsyncClient $client
+     * @param ClientInterface|HttpAsyncClient $client
      */
     public function createClient($client): PluginClient
     {
         if (!$client instanceof ClientInterface && !$client instanceof HttpAsyncClient) {
-            throw new \RuntimeException('You must provide a valid http client');
+            throw new \TypeError(
+                sprintf('%s::createClient(): Argument #1 ($client) must be of type %s|%s, %s given', self::class, ClientInterface::class, HttpAsyncClient::class, get_debug_type($client))
+            );
         }
 
         $plugins = $this->plugins;

--- a/src/PluginClientFactory.php
+++ b/src/PluginClientFactory.php
@@ -47,6 +47,12 @@ final class PluginClientFactory
      */
     public function createClient($client, array $plugins = [], array $options = []): PluginClient
     {
+        if (!$client instanceof ClientInterface && !$client instanceof HttpAsyncClient) {
+            throw new \TypeError(
+                sprintf('%s::createClient(): Argument #1 ($client) must be of type %s|%s, %s given', self::class, ClientInterface::class, HttpAsyncClient::class, get_debug_type($client))
+            );
+        }
+
         if (static::$factory) {
             $factory = static::$factory;
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    |yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

This PR consistently implements union type checking. Note that in the cases where there wasn't already a type check in place, the code would have still crashed later, but it is much harder for a programmer to know what went wrong, because it wasn't thrown early enough, where they actually made the made method called, and instead was thrown from deeper in the internals.