### PR TITLE
Replacement memory leak hotfix

### DIFF
--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Http\Client\Common;
 
+use function array_reverse;
 use Http\Client\Common\Exception\LoopException;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
-use function array_reverse;
 
 final class PluginChain
 {
@@ -24,9 +24,12 @@ final class PluginChain
     private $restarts = 0;
 
     /**
-     * @param Plugin[] $plugins
-     * @param callable $clientCallable
-     * @param int $maxRestarts
+     * @param Plugin[] $plugins        A plugin chain
+     * @param callable $clientCallable Callable making the HTTP call
+     * @param array    $options        {
+     *
+     *     @var int $max_restarts
+     * }
      */
     public function __construct(array $plugins, callable $clientCallable, array $options = [])
     {

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -27,11 +27,11 @@ final class PluginChain
      * @param callable $clientCallable
      * @param int $maxRestarts
      */
-    public function __construct(array $plugins, callable $clientCallable, int $maxRestarts)
+    public function __construct(array $plugins, callable $clientCallable, array $options = [])
     {
         $this->plugins = $plugins;
         $this->clientCallable = $clientCallable;
-        $this->maxRestarts = $maxRestarts;
+        $this->maxRestarts = (int) ($options['max_restarts'] ?? 0);
     }
 
     private function createChain(): callable

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -7,6 +7,7 @@ namespace Http\Client\Common;
 use Http\Client\Common\Exception\LoopException;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
+use function array_reverse;
 
 final class PluginChain
 {
@@ -37,8 +38,9 @@ final class PluginChain
     private function createChain(): callable
     {
         $lastCallable = $this->clientCallable;
+        $reversedPlugins = array_reverse($this->plugins);
 
-        foreach ($this->plugins as $plugin) {
+        foreach ($reversedPlugins as $plugin) {
             $lastCallable = function (RequestInterface $request) use ($plugin, $lastCallable) {
                 return $plugin->handleRequest($request, $lastCallable, $this);
             };

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Client\Common;
+
+use Http\Client\Common\Exception\LoopException;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+
+final class PluginChain
+{
+    /** @var Plugin[] */
+    private $plugins;
+
+    /** @var callable */
+    private $clientCallable;
+
+    /** @var int */
+    private $maxRestarts;
+
+    /** @var int */
+    private $restarts = 0;
+
+    /**
+     * @param Plugin[] $plugins
+     * @param callable $clientCallable
+     * @param int $maxRestarts
+     */
+    public function __construct(array $plugins, callable $clientCallable, int $maxRestarts)
+    {
+        $this->plugins = $plugins;
+        $this->clientCallable = $clientCallable;
+        $this->maxRestarts = $maxRestarts;
+    }
+
+    private function createChain(): callable
+    {
+        $lastCallable = $this->clientCallable;
+
+        foreach ($this->plugins as $plugin) {
+            $lastCallable = function (RequestInterface $request) use ($plugin, $lastCallable) {
+                return $plugin->handleRequest($request, $lastCallable, $this);
+            };
+        }
+
+        return $lastCallable;
+    }
+
+    public function __invoke(RequestInterface $request): Promise
+    {
+        if ($this->restarts > $this->maxRestarts) {
+            throw new LoopException('Too many restarts in plugin client', $request);
+        }
+
+        ++$this->restarts;
+
+        return $this->createChain()($request);
+    }
+}

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Http\Client\Common;
 
-use Http\Client\Common\Exception\LoopException;
 use Http\Client\Exception as HttplugException;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
@@ -44,11 +43,11 @@ final class PluginClient implements HttpClient, HttpAsyncClient
     private $options;
 
     /**
-     * @param ClientInterface|HttpAsyncClient $client
-     * @param Plugin[]                        $plugins
+     * @param ClientInterface|HttpAsyncClient $client  An HTTP async client
+     * @param Plugin[]                        $plugins A plugin chain
      * @param array                           $options {
      *
-     *     @var int      $max_restarts
+     *     @var int $max_restarts
      * }
      */
     public function __construct($client, array $plugins = [], array $options = [])
@@ -120,11 +119,11 @@ final class PluginClient implements HttpClient, HttpAsyncClient
     /**
      * Create the plugin chain.
      *
-     * @param Plugin[] $pluginList     A list of plugins
+     * @param Plugin[] $plugins        A plugin chain
      * @param callable $clientCallable Callable making the HTTP call
      */
-    private function createPluginChain(array $pluginList, callable $clientCallable): callable
+    private function createPluginChain(array $plugins, callable $clientCallable): callable
     {
-        return new PluginChain($pluginList, $clientCallable, $this->options);
+        return new PluginChain($plugins, $clientCallable, $this->options);
     }
 }

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -125,6 +125,6 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      */
     private function createPluginChain(array $pluginList, callable $clientCallable): callable
     {
-        return new PluginChain($pluginList, $clientCallable, $this->options['max_restarts']);
+        return new PluginChain($pluginList, $clientCallable, $this->options);
     }
 }

--- a/tests/PluginChainTest.php
+++ b/tests/PluginChainTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Http\Client\Common;
+
+use Http\Client\Common\Exception\LoopException;
+use Http\Client\Common\Plugin;
+use Http\Client\Common\PluginChain;
+use Http\Promise\Promise;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+
+class PluginChainTest extends TestCase
+{
+    private function createPlugin(callable $func): Plugin
+    {
+        return new class ($func) implements Plugin
+        {
+            public $func;
+
+            public function __construct(callable $func)
+            {
+                $this->func = $func;
+            }
+
+            public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+            {
+                ($this->func)($request, $next, $first);
+
+                return $next($request);
+            }
+        };
+    }
+
+    public function testChainShouldInvokePluginsInReversedOrder(): void
+    {
+        $pluginOrderCalls = [];
+
+        $plugin1 = $this->createPlugin(static function () use (&$pluginOrderCalls) {
+            $pluginOrderCalls[] = 'plugin1';
+        });
+        $plugin2 = $this->createPlugin(static function () use (&$pluginOrderCalls) {
+            $pluginOrderCalls[] = 'plugin2';
+        });
+
+        $request = $this->prophesize(RequestInterface::class);
+        $responsePromise = $this->prophesize(Promise::class);
+
+        $clientCallable = static function () use ($responsePromise) {
+            return $responsePromise->reveal();
+        };
+
+        $pluginOrderCalls = [];
+
+        $plugins = [
+            $plugin1,
+            $plugin2,
+        ];
+
+        $pluginChain = new PluginChain($plugins, $clientCallable);
+
+        $result = $pluginChain($request->reveal());
+
+        $this->assertSame($responsePromise->reveal(), $result);
+        $this->assertSame(['plugin1', 'plugin2'], $pluginOrderCalls);
+    }
+
+    public function testShouldThrowLoopExceptionOnMaxRestarts(): void
+    {
+        $this->expectException(LoopException::class);
+
+        $request = $this->prophesize(RequestInterface::class);
+        $responsePromise = $this->prophesize(Promise::class);
+        $calls = 0;
+        $clientCallable = static function () use ($responsePromise, &$calls) {
+            ++$calls;
+
+            return $responsePromise->reveal();
+        };
+
+        $pluginChain = new PluginChain([], $clientCallable, ['max_restarts' => 2]);
+
+        $pluginChain($request->reveal());
+        $this->assertSame(1, $calls);
+        $pluginChain($request->reveal());
+        $this->assertSame(2, $calls);
+        $pluginChain($request->reveal());
+        $this->assertSame(3, $calls);
+        $pluginChain($request->reveal());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #184
| License         | MIT


### Original description:

There is a big memory leak when using the PluginClient with plugins.

Example code to reproduce the issue:

```php
use Http\Client\Curl\Client;

$samples = 50;
$curlClient = new Client();
$requestFactory = $container->get(\Psr\Http\Message\RequestFactoryInterface::class);
$pluginClient = new \Http\Client\Common\PluginClient(
    $curlClient,
    [
        new \Http\Client\Common\Plugin\RedirectPlugin(),
    ]
);

$request = $requestFactory->createRequest('GET', 'https://google.it');
for ($i = 1; $i <= $samples; $i++) {
    $pluginClient->sendRequest($request);
    echo 'memory: ' . memory_get_usage() . PHP_EOL;
    // gc_collect_cycles(); without this, gc isn't able to free memory
}
```

This PR fixes it removing useless variable reference.