### PR TITLE
More specific plugin type doc

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -24,8 +24,8 @@ interface Plugin
      *
      * @see http://docs.php-http.org/en/latest/plugins/build-your-own.html
      *
-     * @param callable $next  Next middleware in the chain, the request is passed as the first argument
-     * @param callable $first First middleware in the chain, used to to restart a request
+     * @param callable(RequestInterface): Promise $next  Next middleware in the chain, the request is passed as the first argument
+     * @param callable(RequestInterface): Promise $first First middleware in the chain, used to to restart a request
      *
      * @return Promise Resolves a PSR-7 Response or fails with an Http\Client\Exception (The same as HttpAsyncClient)
      */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,7 +6,6 @@ namespace Http\Client\Common;
 
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * A plugin is a middleware to transform the request and/or the response.
@@ -25,8 +24,8 @@ interface Plugin
      *
      * @see http://docs.php-http.org/en/latest/plugins/build-your-own.html
      *
-     * @param callable(ResponseInterface): Promise $next  Next middleware in the chain, the request is passed as the first argument
-     * @param callable(ResponseInterface): Promise $first First middleware in the chain, used to to restart a request
+     * @param callable(RequestInterface): Promise $next  Next middleware in the chain, the request is passed as the first argument
+     * @param callable(RequestInterface): Promise $first First middleware in the chain, used to to restart a request
      *
      * @return Promise Resolves a PSR-7 Response or fails with an Http\Client\Exception (The same as HttpAsyncClient)
      */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,6 +6,7 @@ namespace Http\Client\Common;
 
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * A plugin is a middleware to transform the request and/or the response.
@@ -24,8 +25,8 @@ interface Plugin
      *
      * @see http://docs.php-http.org/en/latest/plugins/build-your-own.html
      *
-     * @param callable(RequestInterface): Promise $next  Next middleware in the chain, the request is passed as the first argument
-     * @param callable(RequestInterface): Promise $first First middleware in the chain, used to to restart a request
+     * @param callable(ResponseInterface): Promise $next  Next middleware in the chain, the request is passed as the first argument
+     * @param callable(ResponseInterface): Promise $first First middleware in the chain, used to to restart a request
      *
      * @return Promise Resolves a PSR-7 Response or fails with an Http\Client\Exception (The same as HttpAsyncClient)
      */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no|
| Deprecations?   | no|yes
| License         | MIT

Static analysers (such as Psalm) complain if someone adds this typing information to their own class which extends this interface because what they have affectively done is specialised the types, which is not allowed. It's the same as an interface saying `string|int` but the implementation only accepting `string`. So, with this in mind, we should take the opportunity to provide the most specific type information we can.

For reference, an error produced by Psalm (without this PR):

```
ERROR: MoreSpecificImplementedParamType - src/HttpClient/Plugin/Authentication.php:62:71 - Argument 2 of Bitbucket\HttpClient\Plugin\Authentication::handleRequest has the more specific type 'callable(Psr\Http\Message\RequestInterface):Http\Promise\Promise', expecting 'callable' as defined by Http\Client\Common\Plugin::handleRequest (see https://psalm.dev/140)
    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise


ERROR: MoreSpecificImplementedParamType - src/HttpClient/Plugin/Authentication.php:62:87 - Argument 3 of Bitbucket\HttpClient\Plugin\Authentication::handleRequest has the more specific type 'callable(Psr\Http\Message\RequestInterface):Http\Promise\Promise', expecting 'callable' as defined by Http\Client\Common\Plugin::handleRequest (see https://psalm.dev/140)
    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
```

and by PHPStan:

```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   HttpClient/Plugin/Authentication.php                                                                                                                                  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  62     Parameter #2 $next (callable(Psr\Http\Message\RequestInterface): Http\Promise\Promise) of method Bitbucket\HttpClient\Plugin\Authentication::handleRequest() should   
         be contravariant with parameter $next (callable(): mixed) of method Http\Client\Common\Plugin::handleRequest()                                                        
  62     Parameter #3 $first (callable(Psr\Http\Message\RequestInterface): Http\Promise\Promise) of method Bitbucket\HttpClient\Plugin\Authentication::handleRequest() should  
         be contravariant with parameter $first (callable(): mixed) of method Http\Client\Common\Plugin::handleRequest()                                                       
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
```