### PR TITLE
Fix broken HttpMethodsClient with PSR RequestFactory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2.x-dev"
+            "dev-master": "2.3.x-dev"
         }
     }
 }

--- a/src/HttpMethodsClient.php
+++ b/src/HttpMethodsClient.php
@@ -116,7 +116,7 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
     private function createRequest(string $method, $uri, array $headers = [], $body = null): RequestInterface
     {
         if ($this->requestFactory instanceof RequestFactory) {
-            return = $this->requestFactory->createRequest(
+            return $this->requestFactory->createRequest(
                 $method,
                 $uri,
                 $headers,

--- a/src/HttpMethodsClient.php
+++ b/src/HttpMethodsClient.php
@@ -9,6 +9,9 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 
 final class HttpMethodsClient implements HttpMethodsClientInterface
 {
@@ -23,9 +26,14 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
     private $requestFactory;
 
     /**
+     * @var StreamFactoryInterface|null
+     */
+    private $streamFactory;
+
+    /**
      * @param RequestFactory|RequestFactoryInterface
      */
-    public function __construct(ClientInterface $httpClient, $requestFactory)
+    public function __construct(ClientInterface $httpClient, $requestFactory, StreamFactoryInterface $streamFactory = null)
     {
         if (!$requestFactory instanceof RequestFactory && !$requestFactory instanceof RequestFactoryInterface) {
             throw new \TypeError(
@@ -33,8 +41,13 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
             );
         }
 
+        if (!$requestFactory instanceof RequestFactory && null === $streamFactory) {
+            @trigger_error(sprintf('Passing a %s without a %s to %s::__construct() is deprecated as of version 2.3 and will be disallowed in version 3.0. A stream factory is required to create a request with a string body.', RequestFactoryInterface::class, StreamFactoryInterface::class, self::class));
+        }
+
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory;
     }
 
     public function get($uri, array $headers = []): ResponseInterface
@@ -79,12 +92,55 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
 
     public function send(string $method, $uri, array $headers = [], $body = null): ResponseInterface
     {
-        return $this->sendRequest($this->requestFactory->createRequest(
-            $method,
-            $uri,
-            $headers,
-            $body
-        ));
+        if (!is_string($uri) && !$uri instanceof UriInterface) {
+            throw new \TypeError(
+                sprintf('%s::send(): Argument #2 ($uri) must be of type string|%s, %s given', self::class, UriInterface::class, get_debug_type($uri))
+            );
+        }
+
+        if (!is_string($body) && !$body instanceof StreamInterface && null !== $body) {
+            throw new \TypeError(
+                sprintf('%s::send(): Argument #4 ($body) must be of type string|%s|null, %s given', self::class, StreamInterface::class, get_debug_type($body))
+            );
+        }
+
+        return $this->sendRequest(
+            self::createRequest($method, $uri, $headers, $body)
+        );
+    }
+
+    /**
+     * @param string|UriInterface         $uri
+     * @param string|StreamInterface|null $body
+     */
+    private function createRequest(string $method, $uri, array $headers = [], $body = null): RequestInterface
+    {
+        if ($this->requestFactory instanceof RequestFactory) {
+            return = $this->requestFactory->createRequest(
+                $method,
+                $uri,
+                $headers,
+                $body
+            );
+        }
+
+        if (is_string($body) && null === $this->streamFactory) {
+            throw new \RuntimeException('Cannot create request: A stream factory is required to create a request with a string body.');
+        }
+
+        $request = $this->requestFactory->createRequest($method, $uri);
+
+        foreach ($headers as $key => $value) {
+            $request = $request->withHeader($key, $value);
+        }
+
+        if (null !== $body) {
+            $request = $request->withBody(
+                is_string($body) ? $this->streamFactory->createStream($body) : $body
+            );
+        }
+
+        return $request;
     }
 
     public function sendRequest(RequestInterface $request): ResponseInterface

--- a/src/HttpMethodsClient.php
+++ b/src/HttpMethodsClient.php
@@ -42,7 +42,7 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
         }
 
         if (!$requestFactory instanceof RequestFactory && null === $streamFactory) {
-            @trigger_error(sprintf('Passing a %s without a %s to %s::__construct() is deprecated as of version 2.3 and will be disallowed in version 3.0. A stream factory is required to create a request with a string body.', RequestFactoryInterface::class, StreamFactoryInterface::class, self::class));
+            @trigger_error(sprintf('Passing a %s without a %s to %s::__construct() is deprecated as of version 2.3 and will be disallowed in version 3.0. A stream factory is required to create a request with a non-empty string body.', RequestFactoryInterface::class, StreamFactoryInterface::class, self::class));
         }
 
         $this->httpClient = $httpClient;
@@ -124,8 +124,8 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
             );
         }
 
-        if (is_string($body) && null === $this->streamFactory) {
-            throw new \RuntimeException('Cannot create request: A stream factory is required to create a request with a string body.');
+        if (is_string($body) && '' !== $body && null === $this->streamFactory) {
+            throw new \RuntimeException('Cannot create request: A stream factory is required to create a request with a non-empty string body.');
         }
 
         $request = $this->requestFactory->createRequest($method, $uri);
@@ -134,7 +134,7 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
             $request = $request->withHeader($key, $value);
         }
 
-        if (null !== $body) {
+        if (null !== $body && '' !== $body) {
             $request = $request->withBody(
                 is_string($body) ? $this->streamFactory->createStream($body) : $body
             );


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #201
| License         | MIT

The PSR request factory doesn't know anything about headers or body, and these parameters are silently thrown away!

In order to avoid these, we must set them on the request afterwards. Note that by doing this we have revealed a hidden dependency on a stream factory. I have allowed for this in BC-preserving manner.