### PR TITLE
Added `strict` option for RedirectPlugin not to modify request method…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `strict` option to `RedirectPlugin`
+- `strict` option to `RedirectPlugin` to allow preserving the request method on redirections with status 300, 301 and 302.
 
 ## 2.3.0 - 2020-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.4.0 (unreleased)
+
+### Added
+
+- `strict` option to `RedirectPlugin`
+
 ## 2.3.0 - 2020-07-21
 
 ### Fixed
@@ -112,7 +118,7 @@
 
 ## 1.7.0 - 2017-11-30
 
-### Added 
+### Added
 
 - Symfony 4 support
 
@@ -132,12 +138,12 @@
 
 ### Changed
 
-- The `RetryPlugin` does now wait between retries. To disable/change this feature you must write something like: 
- 
+- The `RetryPlugin` does now wait between retries. To disable/change this feature you must write something like:
+
 ```php
-$plugin = new RetryPlugin(['delay' => function(RequestInterface $request, Exception $e, $retries) { 
-  return 0; 
-}); 
+$plugin = new RetryPlugin(['delay' => function(RequestInterface $request, Exception $e, $retries) {
+  return 0;
+});
 ```
 
 ### Deprecated

--- a/src/Plugin/RedirectPlugin.php
+++ b/src/Plugin/RedirectPlugin.php
@@ -105,7 +105,7 @@ final class RedirectPlugin implements Plugin
      * @param array $config {
      *
      *     @var bool|string[] $preserve_header True keeps all headers, false remove all of them, an array is interpreted as a list of header names to keep
-     *     @var bool $use_default_for_multiple Whether the location header must be directly used for a multiple redirection status code (300).
+     *     @var bool $use_default_for_multiple Whether the location header must be directly used for a multiple redirection status code (300)
      *     @var bool $strict When true, redirect codes 300, 301, 302 will not modify request method and body.
      * }
      */

--- a/src/Plugin/RedirectPlugin.php
+++ b/src/Plugin/RedirectPlugin.php
@@ -106,6 +106,7 @@ final class RedirectPlugin implements Plugin
      *
      *     @var bool|string[] $preserve_header True keeps all headers, false remove all of them, an array is interpreted as a list of header names to keep
      *     @var bool $use_default_for_multiple Whether the location header must be directly used for a multiple redirection status code (300).
+     *     @var bool $strict When true, redirect codes 300, 301, 302 will not modify request method and body.
      * }
      */
     public function __construct(array $config = [])
@@ -114,9 +115,11 @@ final class RedirectPlugin implements Plugin
         $resolver->setDefaults([
             'preserve_header' => true,
             'use_default_for_multiple' => true,
+            'strict' => false,
         ]);
         $resolver->setAllowedTypes('preserve_header', ['bool', 'array']);
         $resolver->setAllowedTypes('use_default_for_multiple', 'bool');
+        $resolver->setAllowedTypes('strict', 'bool');
         $resolver->setNormalizer('preserve_header', function (OptionsResolver $resolver, $value) {
             if (is_bool($value) && false === $value) {
                 return [];
@@ -128,6 +131,12 @@ final class RedirectPlugin implements Plugin
 
         $this->preserveHeader = $options['preserve_header'];
         $this->useDefaultForMultiple = $options['use_default_for_multiple'];
+
+        if ($options['strict']) {
+            $this->redirectCodes[300]['switch'] = false;
+            $this->redirectCodes[301]['switch'] = false;
+            $this->redirectCodes[302]['switch'] = false;
+        }
     }
 
     /**


### PR DESCRIPTION
… on statuses 300, 301, 302

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #207, partially #205
| License         | MIT


#### What's in this PR?

Resolves #207 by allowing to follow redirect specs for 301 and 302 more strictly - not modifying request method 



#### Example Usage

``` php
        $plugins = $plugins ?? [
            new RedirectPlugin(['strict' => true]),
        ];

        $httpClient = (new PluginClientFactory())->createClient(
            Psr18ClientDiscovery::find(),
            $plugins
        );
```


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
