### PR TITLE
Remove spl_object_hash to a version compatible PHP 5.X

### DIFF
--- a/src/Plugin/AddPathPlugin.php
+++ b/src/Plugin/AddPathPlugin.php
@@ -42,17 +42,42 @@ final class AddPathPlugin implements Plugin
     }
 
     /**
+     * Adds a prefix in the beginning of the URL's path.
+     *
+     * The prefix is not added if that prefix is already on the URL's path. This will fail on the edge
+     * case of the prefix being repeated, for example if `https://example.com/api/api/foo` is a valid
+     * URL on the server and the configured prefix is `/api`.
+     *
+     * We looked at other solutions, but they are all much more complicated, while still having edge
+     * cases:
+     * - Doing an spl_object_hash on `$first` will lead to collisions over time because over time the
+     *   hash can collide.
+     * - Have the PluginClient provide a magic header to identify the request chain and only apply
+     *   this plugin once.
+     *
+     * There are 2 reasons for the AddPathPlugin to be executed twice on the same request:
+     * - A plugin can restart the chain by calling `$first`, e.g. redirect
+     * - A plugin can call `$next` more than once, e.g. retry
+     *
+     * Depending on the scenario, the path should or should not be added. E.g. `$first` could
+     * be called after a redirect response from the server. The server likely already has the
+     * correct path.
+     *
+     * No solution fits all use cases. This implementation will work fine for the common use cases.
+     * If you have a specific situation where this is not the right thing, you can build a custom plugin
+     * that does exactly what you need.
+     *
      * {@inheritdoc}
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first)
     {
-        $identifier = spl_object_hash((object) $first);
+        $prepend = $this->uri->getPath();
+        $path = $request->getUri()->getPath();
 
-        if (!array_key_exists($identifier, $this->alteredRequests)) {
+        if (substr($path, 0, strlen($prepend)) !== $prepend) {
             $request = $request->withUri($request->getUri()
-                ->withPath($this->uri->getPath().$request->getUri()->getPath())
-            );
-            $this->alteredRequests[$identifier] = $identifier;
+                 ->withPath($prepend.$path)
+             );
         }
 
         return $next($request);


### PR DESCRIPTION
…ble php 5.6

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #187 
| License         | MIT


#### What's in this PR?

Just apply the same fix for spl_object_hash collisions for an oldest tag compatible with php5.x


#### Why?

Because old projects using PHP 5.x need also this fix
