### PR TITLE
Dependency: Symfony/options-resolver allow ^6.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        symfony: ['2', '3', '4']
+        symfony: ['2', '3', '4', '5', '6']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        symfony: ['2', '3', '4', '5', '6']
+        symfony: ['4', '5', '6']
 
     steps:
       - name: Checkout code
@@ -85,8 +85,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require dunglas/symfony-lock:v${{ matrix.symfony }} --no-interaction --no-update
-          composer update --prefer-dist --no-interaction --prefer-stable --prefer-lowest --no-progress
+          SYMFONY_REQUIRE=${{ matrix.symfony }} composer update --prefer-dist --no-interaction --prefer-stable --prefer-lowest --no-progress
 
       - name: Execute tests
         run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          SYMFONY_REQUIRE=${{ matrix.symfony }} composer update --prefer-dist --no-interaction --prefer-stable --prefer-lowest --no-progress
+          composer require --no-update --no-interaction --no-progress symfony/flex
+          composer config extra.symfony.require ${{ matrix.symfony}}
+          composer update --prefer-dist --no-interaction --prefer-stable --prefer-lowest --no-progress
 
       - name: Execute tests
         run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /phpunit.xml
 /phpstan.neon
 /vendor/
+
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
-        "symfony/options-resolver": "^2.6 || ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0",
+        "symfony/options-resolver": "~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0",
         "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
-        "symfony/options-resolver": "^2.6 || ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0",
+        "symfony/options-resolver": "^2.6 || ^3.4.20 || ~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0",
         "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | None
| License         | MIT


#### What's in this PR?

Update `composer.json` to allow the upcoming `^6.0` for `symfony/options-resolver`.


#### Why?

To support Symfony 6.

