### PR TITLE
Remove dependency on php-http/message-factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "php": "^7.1 || ^8.0",
         "php-http/httplug": "^2.0",
         "php-http/message": "^1.6",
-        "php-http/message-factory": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT

This package does not require `php-http/message-factory`. Since all interfaces from it have been removed, it's better to drop the dep.