### PR TITLE
Fix pending PHPStan errors in PR #233

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,11 +26,6 @@ parameters:
             count: 1
             path: src/PluginClient.php
 
-        -
-            message: "#^Method Http\\\\Client\\\\Common\\\\EmulatedHttpClient\\:\\:sendRequest\\(\\) should return Psr\\\\Http\\\\Message\\\\ResponseInterface but returns mixed\\.$#"
-            count: 1
-            path: src/EmulatedHttpClient.php
-
         # we still support the obsolete RequestFactory for BC but do not require the package anymore
         -
             message: "#^Call to method createRequest\\(\\) on an unknown class Http\\\\Message\\\\RequestFactory\\.$#"
@@ -51,18 +46,3 @@ parameters:
             message: "#^Property Http\\\\Client\\\\Common\\\\HttpMethodsClient\\:\\:\\$requestFactory has unknown class Http\\\\Message\\\\RequestFactory as its type\\.$#"
             count: 1
             path: src/HttpMethodsClient.php
-
-        -
-            message: "#^Anonymous function should return Psr\\\\Http\\\\Message\\\\ResponseInterface but returns mixed\\.$#"
-            count: 1
-            path: src/Plugin/RedirectPlugin.php
-
-        -
-            message: "#^Method Http\\\\Client\\\\Common\\\\Plugin\\\\RetryPlugin\\:\\:retry\\(\\) should return Psr\\\\Http\\\\Message\\\\ResponseInterface but returns mixed\\.$#"
-            count: 1
-            path: src/Plugin/RetryPlugin.php
-
-        -
-            message: "#^Method Http\\\\Client\\\\Common\\\\PluginClient\\:\\:sendRequest\\(\\) should return Psr\\\\Http\\\\Message\\\\ResponseInterface but returns mixed\\.$#"
-            count: 2
-            path: src/PluginClient.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -57,18 +57,6 @@ parameters:
             count: 1
             path: src/Plugin/RedirectPlugin.php
 
-        # phpstan is confused by the optional dependencies. we check for existence first
-        -
-            message: "#^Method Http\\\\Client\\\\Common\\\\Plugin\\\\RedirectPlugin::guessStreamFactory\\(\\) should return Psr\\\\Http\\\\Message\\\\StreamFactoryInterface\\|null but returns Nyholm\\\\Psr7\\\\Factory\\\\Psr17Factory\\.$#"
-            count: 1
-            path: src/Plugin/RedirectPlugin.php
-
-        # phpstan is confused by the optional dependencies. we check for existence first
-        -
-            message: "#^Call to static method streamFor\\(\\) on an unknown class GuzzleHttp\\\\Psr7\\\\Utils\\.$#"
-            count: 1
-            path: src/Plugin/RedirectPlugin.php
-
         -
             message: "#^Method Http\\\\Client\\\\Common\\\\Plugin\\\\RetryPlugin\\:\\:retry\\(\\) should return Psr\\\\Http\\\\Message\\\\ResponseInterface but returns mixed\\.$#"
             count: 1

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * A deferred allow to return a promise which has not been resolved yet.
+ *
+ * @implements Promise<ResponseInterface>
  */
 final class Deferred implements Promise
 {
@@ -51,6 +53,11 @@ final class Deferred implements Promise
         $this->onRejectedCallbacks = [];
     }
 
+    /**
+     * @param callable(ResponseInterface): ResponseInterface|null $onFulfilled
+     * @param callable(\Throwable): ResponseInterface|null $onRejected
+     * @return Promise<ResponseInterface>
+     */
     public function then(callable $onFulfilled = null, callable $onRejected = null): Promise
     {
         $deferred = new self($this->waitCallback);
@@ -90,6 +97,7 @@ final class Deferred implements Promise
 
     /**
      * Resolve this deferred with a Response.
+     * @param ResponseInterface $response
      */
     public function resolve(ResponseInterface $response): void
     {
@@ -122,6 +130,9 @@ final class Deferred implements Promise
         }
     }
 
+    /**
+     * {@inheritDoc}
+    */
     public function wait($unwrap = true)
     {
         if (Promise::PENDING === $this->state) {

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -51,9 +51,6 @@ final class Deferred implements Promise
         $this->onRejectedCallbacks = [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function then(callable $onFulfilled = null, callable $onRejected = null): Promise
     {
         $deferred = new self($this->waitCallback);
@@ -86,9 +83,6 @@ final class Deferred implements Promise
         return $deferred;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getState(): string
     {
         return $this->state;
@@ -128,9 +122,6 @@ final class Deferred implements Promise
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function wait($unwrap = true)
     {
         if (Promise::PENDING === $this->state) {

--- a/src/HttpAsyncClientDecorator.php
+++ b/src/HttpAsyncClientDecorator.php
@@ -20,8 +20,6 @@ trait HttpAsyncClientDecorator
     protected $httpAsyncClient;
 
     /**
-     * {@inheritdoc}
-     *
      * @see HttpAsyncClient::sendAsyncRequest
      */
     public function sendAsyncRequest(RequestInterface $request)

--- a/src/HttpAsyncClientDecorator.php
+++ b/src/HttpAsyncClientDecorator.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Http\Client\Common;
 
 use Http\Client\HttpAsyncClient;
+use Http\Promise\Promise;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -21,6 +23,7 @@ trait HttpAsyncClientDecorator
 
     /**
      * @see HttpAsyncClient::sendAsyncRequest
+     * @return Promise<ResponseInterface>
      */
     public function sendAsyncRequest(RequestInterface $request)
     {

--- a/src/HttpAsyncClientEmulator.php
+++ b/src/HttpAsyncClientEmulator.php
@@ -17,15 +17,11 @@ use Psr\Http\Message\ResponseInterface;
 trait HttpAsyncClientEmulator
 {
     /**
-     * {@inheritdoc}
-     *
      * @see HttpClient::sendRequest
      */
     abstract public function sendRequest(RequestInterface $request): ResponseInterface;
 
     /**
-     * {@inheritdoc}
-     *
      * @see HttpAsyncClient::sendAsyncRequest
      */
     public function sendAsyncRequest(RequestInterface $request)

--- a/src/HttpAsyncClientEmulator.php
+++ b/src/HttpAsyncClientEmulator.php
@@ -23,6 +23,7 @@ trait HttpAsyncClientEmulator
 
     /**
      * @see HttpAsyncClient::sendAsyncRequest
+     * @return \Http\Promise\Promise<ResponseInterface|\Throwable>
      */
     public function sendAsyncRequest(RequestInterface $request)
     {

--- a/src/HttpClientDecorator.php
+++ b/src/HttpClientDecorator.php
@@ -21,8 +21,6 @@ trait HttpClientDecorator
     protected $httpClient;
 
     /**
-     * {@inheritdoc}
-     *
      * @see ClientInterface::sendRequest
      */
     public function sendRequest(RequestInterface $request): ResponseInterface

--- a/src/HttpClientEmulator.php
+++ b/src/HttpClientEmulator.php
@@ -15,8 +15,6 @@ use Psr\Http\Message\ResponseInterface;
 trait HttpClientEmulator
 {
     /**
-     * {@inheritdoc}
-     *
      * @see HttpClient::sendRequest
      */
     public function sendRequest(RequestInterface $request): ResponseInterface
@@ -27,8 +25,6 @@ trait HttpClientEmulator
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @see HttpAsyncClient::sendAsyncRequest
      */
     abstract public function sendAsyncRequest(RequestInterface $request);

--- a/src/HttpClientPool/HttpClientPool.php
+++ b/src/HttpClientPool/HttpClientPool.php
@@ -52,17 +52,11 @@ abstract class HttpClientPool implements HttpClientPoolInterface
      */
     abstract protected function chooseHttpClient(): HttpClientPoolItem;
 
-    /**
-     * {@inheritdoc}
-     */
     public function sendAsyncRequest(RequestInterface $request)
     {
         return $this->chooseHttpClient()->sendAsyncRequest($request);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
         return $this->chooseHttpClient()->sendRequest($request);

--- a/src/HttpClientPool/HttpClientPool.php
+++ b/src/HttpClientPool/HttpClientPool.php
@@ -7,6 +7,7 @@ namespace Http\Client\Common\HttpClientPool;
 use Http\Client\Common\Exception\HttpClientNotFoundException;
 use Http\Client\Common\HttpClientPool as HttpClientPoolInterface;
 use Http\Client\HttpAsyncClient;
+use Http\Promise\Promise;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -52,6 +53,9 @@ abstract class HttpClientPool implements HttpClientPoolInterface
      */
     abstract protected function chooseHttpClient(): HttpClientPoolItem;
 
+    /**
+     * @return Promise<ResponseInterface>
+     */
     public function sendAsyncRequest(RequestInterface $request)
     {
         return $this->chooseHttpClient()->sendAsyncRequest($request);

--- a/src/HttpClientPool/HttpClientPoolItem.php
+++ b/src/HttpClientPool/HttpClientPoolItem.php
@@ -69,9 +69,6 @@ class HttpClientPoolItem implements HttpClient, HttpAsyncClient
         $this->reenableAfter = $reenableAfter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
         if ($this->isDisabled()) {
@@ -92,9 +89,6 @@ class HttpClientPoolItem implements HttpClient, HttpAsyncClient
         return $response;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sendAsyncRequest(RequestInterface $request)
     {
         if ($this->isDisabled()) {

--- a/src/HttpClientPool/HttpClientPoolItem.php
+++ b/src/HttpClientPool/HttpClientPoolItem.php
@@ -8,6 +8,7 @@ use Http\Client\Common\FlexibleHttpClient;
 use Http\Client\Exception;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
+use Http\Promise\Promise;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -89,6 +90,9 @@ class HttpClientPoolItem implements HttpClient, HttpAsyncClient
         return $response;
     }
 
+    /**
+     * @return Promise<ResponseInterface>
+     */
     public function sendAsyncRequest(RequestInterface $request)
     {
         if ($this->isDisabled()) {

--- a/src/HttpClientPool/LeastUsedClientPool.php
+++ b/src/HttpClientPool/LeastUsedClientPool.php
@@ -15,9 +15,6 @@ use Http\Client\Common\Exception\HttpClientNotFoundException;
  */
 final class LeastUsedClientPool extends HttpClientPool
 {
-    /**
-     * {@inheritdoc}
-     */
     protected function chooseHttpClient(): HttpClientPoolItem
     {
         $clientPool = array_filter($this->clientPool, function (HttpClientPoolItem $clientPoolItem) {

--- a/src/HttpClientPool/RandomClientPool.php
+++ b/src/HttpClientPool/RandomClientPool.php
@@ -13,9 +13,6 @@ use Http\Client\Common\Exception\HttpClientNotFoundException;
  */
 final class RandomClientPool extends HttpClientPool
 {
-    /**
-     * {@inheritdoc}
-     */
     protected function chooseHttpClient(): HttpClientPoolItem
     {
         $clientPool = array_filter($this->clientPool, function (HttpClientPoolItem $clientPoolItem) {

--- a/src/HttpClientPool/RoundRobinClientPool.php
+++ b/src/HttpClientPool/RoundRobinClientPool.php
@@ -13,9 +13,6 @@ use Http\Client\Common\Exception\HttpClientNotFoundException;
  */
 final class RoundRobinClientPool extends HttpClientPool
 {
-    /**
-     * {@inheritdoc}
-     */
     protected function chooseHttpClient(): HttpClientPoolItem
     {
         $last = current($this->clientPool);

--- a/src/HttpClientRouter.php
+++ b/src/HttpClientRouter.php
@@ -12,8 +12,6 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * {@inheritdoc}
- *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
 final class HttpClientRouter implements HttpClientRouterInterface
@@ -23,17 +21,11 @@ final class HttpClientRouter implements HttpClientRouterInterface
      */
     private $clients = [];
 
-    /**
-     * {@inheritdoc}
-     */
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
         return $this->chooseHttpClient($request)->sendRequest($request);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sendAsyncRequest(RequestInterface $request)
     {
         return $this->chooseHttpClient($request)->sendAsyncRequest($request);

--- a/src/HttpClientRouter.php
+++ b/src/HttpClientRouter.php
@@ -7,6 +7,7 @@ namespace Http\Client\Common;
 use Http\Client\Common\Exception\HttpClientNoMatchException;
 use Http\Client\HttpAsyncClient;
 use Http\Message\RequestMatcher;
+use Http\Promise\Promise;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -26,6 +27,9 @@ final class HttpClientRouter implements HttpClientRouterInterface
         return $this->chooseHttpClient($request)->sendRequest($request);
     }
 
+    /**
+     * @return Promise<ResponseInterface>
+     */
     public function sendAsyncRequest(RequestInterface $request)
     {
         return $this->chooseHttpClient($request)->sendAsyncRequest($request);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Http\Client\Common;
 
 use Http\Promise\Promise;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -24,10 +25,10 @@ interface Plugin
      *
      * @see http://docs.php-http.org/en/latest/plugins/build-your-own.html
      *
-     * @param callable(RequestInterface): Promise $next  Next middleware in the chain, the request is passed as the first argument
-     * @param callable(RequestInterface): Promise $first First middleware in the chain, used to to restart a request
+     * @param callable(RequestInterface): Promise<ResponseInterface> $next  Next middleware in the chain, the request is passed as the first argument
+     * @param callable(RequestInterface): Promise<ResponseInterface> $first First middleware in the chain, used to to restart a request
      *
-     * @return Promise Resolves a PSR-7 Response or fails with an Http\Client\Exception (The same as HttpAsyncClient)
+     * @return Promise<ResponseInterface> Resolves a PSR-7 Response or fails with an Http\Client\Exception (The same as HttpAsyncClient)
      */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise;
 }

--- a/src/Plugin/AddHostPlugin.php
+++ b/src/Plugin/AddHostPlugin.php
@@ -48,9 +48,6 @@ final class AddHostPlugin implements Plugin
         $this->replace = $options['replace'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         if ($this->replace || '' === $request->getUri()->getHost()) {

--- a/src/Plugin/AuthenticationPlugin.php
+++ b/src/Plugin/AuthenticationPlugin.php
@@ -26,9 +26,6 @@ final class AuthenticationPlugin implements Plugin
         $this->authentication = $authentication;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $request = $this->authentication->authenticate($request);

--- a/src/Plugin/BaseUriPlugin.php
+++ b/src/Plugin/BaseUriPlugin.php
@@ -24,7 +24,7 @@ final class BaseUriPlugin implements Plugin
     /**
      * @var AddPathPlugin|null
      */
-    private $addPathPlugin = null;
+    private $addPathPlugin;
 
     /**
      * @param UriInterface $uri        Has to contain a host name and can have a path
@@ -39,9 +39,6 @@ final class BaseUriPlugin implements Plugin
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $addHostNext = function (RequestInterface $request) use ($next, $first) {

--- a/src/Plugin/ContentLengthPlugin.php
+++ b/src/Plugin/ContentLengthPlugin.php
@@ -16,9 +16,6 @@ use Psr\Http\Message\RequestInterface;
  */
 final class ContentLengthPlugin implements Plugin
 {
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         if (!$request->hasHeader('Content-Length')) {

--- a/src/Plugin/ContentTypePlugin.php
+++ b/src/Plugin/ContentTypePlugin.php
@@ -57,9 +57,6 @@ final class ContentTypePlugin implements Plugin
         $this->sizeLimit = $options['size_limit'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         if (!$request->hasHeader('Content-Type')) {

--- a/src/Plugin/CookiePlugin.php
+++ b/src/Plugin/CookiePlugin.php
@@ -33,9 +33,6 @@ final class CookiePlugin implements Plugin
         $this->cookieJar = $cookieJar;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $cookies = [];

--- a/src/Plugin/DecoderPlugin.php
+++ b/src/Plugin/DecoderPlugin.php
@@ -48,9 +48,6 @@ final class DecoderPlugin implements Plugin
         $this->useContentEncoding = $options['use_content_encoding'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $encodings = extension_loaded('zlib') ? ['gzip', 'deflate'] : ['identity'];

--- a/src/Plugin/ErrorPlugin.php
+++ b/src/Plugin/ErrorPlugin.php
@@ -54,9 +54,6 @@ final class ErrorPlugin implements Plugin
         $this->onlyServerException = $options['only_server_exception'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $promise = $next($request);

--- a/src/Plugin/HeaderAppendPlugin.php
+++ b/src/Plugin/HeaderAppendPlugin.php
@@ -34,9 +34,6 @@ final class HeaderAppendPlugin implements Plugin
         $this->headers = $headers;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         foreach ($this->headers as $header => $headerValue) {

--- a/src/Plugin/HeaderDefaultsPlugin.php
+++ b/src/Plugin/HeaderDefaultsPlugin.php
@@ -30,9 +30,6 @@ final class HeaderDefaultsPlugin implements Plugin
         $this->headers = $headers;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         foreach ($this->headers as $header => $headerValue) {

--- a/src/Plugin/HeaderRemovePlugin.php
+++ b/src/Plugin/HeaderRemovePlugin.php
@@ -28,9 +28,6 @@ final class HeaderRemovePlugin implements Plugin
         $this->headers = $headers;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         foreach ($this->headers as $header) {

--- a/src/Plugin/HeaderSetPlugin.php
+++ b/src/Plugin/HeaderSetPlugin.php
@@ -30,9 +30,6 @@ final class HeaderSetPlugin implements Plugin
         $this->headers = $headers;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         foreach ($this->headers as $header => $headerValue) {

--- a/src/Plugin/HistoryPlugin.php
+++ b/src/Plugin/HistoryPlugin.php
@@ -29,9 +29,6 @@ final class HistoryPlugin implements Plugin
         $this->journal = $journal;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $journal = $this->journal;

--- a/src/Plugin/QueryDefaultsPlugin.php
+++ b/src/Plugin/QueryDefaultsPlugin.php
@@ -31,9 +31,6 @@ final class QueryDefaultsPlugin implements Plugin
         $this->queryParams = $queryParams;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $uri = $request->getUri();

--- a/src/Plugin/RedirectPlugin.php
+++ b/src/Plugin/RedirectPlugin.php
@@ -158,9 +158,6 @@ final class RedirectPlugin implements Plugin
         $this->streamFactory = $options['stream_factory'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         // Check in storage

--- a/src/Plugin/RequestMatcherPlugin.php
+++ b/src/Plugin/RequestMatcherPlugin.php
@@ -38,9 +38,6 @@ final class RequestMatcherPlugin implements Plugin
         $this->failurePlugin = $delegateOnNoMatch;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         if ($this->requestMatcher->matches($request)) {

--- a/src/Plugin/RequestSeekableBodyPlugin.php
+++ b/src/Plugin/RequestSeekableBodyPlugin.php
@@ -15,9 +15,6 @@ use Psr\Http\Message\RequestInterface;
  */
 final class RequestSeekableBodyPlugin extends SeekableBodyPlugin
 {
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         if (!$request->getBody()->isSeekable()) {

--- a/src/Plugin/ResponseSeekableBodyPlugin.php
+++ b/src/Plugin/ResponseSeekableBodyPlugin.php
@@ -16,9 +16,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 final class ResponseSeekableBodyPlugin extends SeekableBodyPlugin
 {
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         return $next($request)->then(function (ResponseInterface $response) {

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -96,9 +96,6 @@ final class RetryPlugin implements Plugin
         $this->exceptionDelay = $options['exception_delay'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
     {
         $chainIdentifier = spl_object_hash((object) $first);

--- a/src/PluginChain.php
+++ b/src/PluginChain.php
@@ -7,13 +7,14 @@ namespace Http\Client\Common;
 use Http\Client\Common\Exception\LoopException;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 final class PluginChain
 {
     /** @var Plugin[] */
     private $plugins;
 
-    /** @var callable(RequestInterface): Promise */
+    /** @var callable(RequestInterface): Promise<ResponseInterface> */
     private $clientCallable;
 
     /** @var int */
@@ -24,7 +25,7 @@ final class PluginChain
 
     /**
      * @param Plugin[]                            $plugins        A plugin chain
-     * @param callable(RequestInterface): Promise $clientCallable Callable making the HTTP call
+     * @param callable(RequestInterface): Promise<ResponseInterface> $clientCallable Callable making the HTTP call
      * @param array{'max_restarts'?: int}         $options
      */
     public function __construct(array $plugins, callable $clientCallable, array $options = [])
@@ -48,6 +49,9 @@ final class PluginChain
         return $lastCallable;
     }
 
+    /**
+     * @return Promise<ResponseInterface>
+     */
     public function __invoke(RequestInterface $request): Promise
     {
         if ($this->restarts > $this->maxRestarts) {

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -64,9 +64,6 @@ final class PluginClient implements HttpClient, HttpAsyncClient
         $this->options = $this->configure($options);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
         // If the client doesn't support sync calls, call async
@@ -87,9 +84,6 @@ final class PluginClient implements HttpClient, HttpAsyncClient
         return $pluginChain($request)->wait();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sendAsyncRequest(RequestInterface $request)
     {
         $pluginChain = $this->createPluginChain($this->plugins, function (RequestInterface $request) {

--- a/src/PluginClient.php
+++ b/src/PluginClient.php
@@ -84,6 +84,9 @@ final class PluginClient implements HttpClient, HttpAsyncClient
         return $pluginChain($request)->wait();
     }
 
+    /**
+     * @return Promise<ResponseInterface>
+     */
     public function sendAsyncRequest(RequestInterface $request)
     {
         $pluginChain = $this->createPluginChain($this->plugins, function (RequestInterface $request) {
@@ -114,7 +117,7 @@ final class PluginClient implements HttpClient, HttpAsyncClient
      * @param Plugin[] $plugins        A plugin chain
      * @param callable $clientCallable Callable making the HTTP call
      *
-     * @return callable(RequestInterface): Promise
+     * @return callable(RequestInterface): Promise<ResponseInterface>
      */
     private function createPluginChain(array $plugins, callable $clientCallable): callable
     {

--- a/src/PluginClientBuilder.php
+++ b/src/PluginClientBuilder.php
@@ -30,6 +30,9 @@ final class PluginClientBuilder
         return $this;
     }
 
+    /**
+     * @param string|int|float|bool|string[] $value
+     */
     public function setOption(string $name, $value): self
     {
         $this->options[$name] = $value;

--- a/src/PluginClientBuilder.php
+++ b/src/PluginClientBuilder.php
@@ -30,9 +30,6 @@ final class PluginClientBuilder
         return $this;
     }
 
-    /**
-     * @param mixed $value
-     */
     public function setOption(string $name, $value): self
     {
         $this->options[$name] = $value;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | fix #235
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

- Fixes PHPStan failures in [#233](https://github.com/php-http/client-common/pull/233) by adding appropriate generic types to Promise PHPDocs
- Removes previous PHPStan error suppressions that are resolved.


#### To Do

- [ ] pending review/release of https://github.com/php-http/promise/pull/30
