### PR TITLE
feat: drop support for php < 8.1, drop support for symfony < 5.4 (WIP)

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Remove phpspec
-        run: composer remove --dev friends-of-phpspec/phpspec-code-coverage phpspec/phpspec
-
       - name: PHPStan
         uses: docker://oskarstark/phpstan-ga
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: tests
 
 on:
   push:
-      branches:
-          - '*.x'
+    branches:
+      - '*.x'
   pull_request:
 
 jobs:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.1', '7.4', '8.2', '8.3']
+        php: ['8.1']
 
     steps:
       - name: Checkout code
@@ -61,12 +61,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - symfony: '5'
+          - symfony: '5.4.*'
             php-version: '8.1'
-          - symfony: '6'
+          - symfony: '6.4.*'
             php-version: '8.2'
-          - symfony: '7'
-            php-version: '8.3'
+          - symfony: '7.0.*'
+            php-version: '8.2'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout code
@@ -61,14 +61,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - symfony: '4.4.*'
-            php-version: '7.1'
-          - symfony: '5.4.*'
-            php-version: '7.4'
-          - symfony: '6.4.*'
+          - symfony: '5'
+            php-version: '8.1'
+          - symfony: '6'
             php-version: '8.2'
-          - symfony: '7.0.*'
-            php-version: '8.2'
+          - symfony: '7'
+            php-version: '8.3'
 
     steps:
       - name: Checkout code
@@ -103,7 +101,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer:v2
           coverage: xdebug
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "friends-of-phpspec/phpspec-code-coverage:^4.3.2" --no-interaction --no-update
+          composer require "friends-of-phpspec/phpspec-code-coverage:^6.3" --no-interaction --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /vendor/
 
 .phpunit.result.cache
+.phpunit.cache

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 /vendor/
 
 .phpunit.result.cache
-.phpunit.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- drop support for php < 8.1
+- drop support for symfony < 5.4
 - Cleaned up phpdoc.
 
 ## 2.7.1 - 2023-11-30

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "doctrine/instantiator": "^2.0",
         "guzzlehttp/psr7": "^2.6",
         "nyholm/psr7": "^1.8",
         "phpspec/phpspec": "^7.5",

--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,22 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
-        "php-http/httplug": "^2.0",
+        "php": "^8.1",
+        "php-http/httplug": "^2.4",
         "php-http/message": "^1.6",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0 || ^2.0",
-        "symfony/options-resolver": "~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/polyfill-php80": "^1.17"
+        "psr/http-message": "^2.0",
+        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "doctrine/instantiator": "^1.1",
-        "guzzlehttp/psr7": "^1.4",
-        "nyholm/psr7": "^1.2",
-        "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",
-        "phpspec/prophecy": "^1.10.2",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.33 || ^9.6.7"
+        "doctrine/instantiator": "^2.0",
+        "guzzlehttp/psr7": "^2.6",
+        "nyholm/psr7": "^1.8",
+        "phpspec/phpspec": "^7.5",
+        "phpspec/prophecy": "^1.18",
+        "phpunit/phpunit": "^10.5.8",
+        "phpspec/prophecy-phpunit": "^2.1"
     },
     "suggest": {
         "ext-json": "To detect JSON responses with the ContentTypePlugin",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
          bootstrap="./vendor/autoload.php"
          colors="true"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         cacheDirectory=".phpunit.cache"
 >
 
   <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="./vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true">
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+>
 
-    <testsuites>
-        <testsuite name="HTTPlug unit tests">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
+  <testsuites>
+    <testsuite name="HTTPlug unit tests">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+
 </phpunit>

--- a/spec/Plugin/ContentTypePluginSpec.php
+++ b/spec/Plugin/ContentTypePluginSpec.php
@@ -22,7 +22,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     public function it_adds_json_content_type_header(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for(json_encode(['foo' => 'bar'])));
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\Utils::streamFor(json_encode(['foo' => 'bar'])));
         $request->withHeader('Content-Type', 'application/json')->shouldBeCalled()->willReturn($request);
 
         $this->handleRequest($request, PluginStub::next(), function () {});
@@ -31,7 +31,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     public function it_adds_xml_content_type_header(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('<foo>bar</foo>'));
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\Utils::streamFor()('<foo>bar</foo>'));
         $request->withHeader('Content-Type', 'application/xml')->shouldBeCalled()->willReturn($request);
 
         $this->handleRequest($request, PluginStub::next(), function () {});
@@ -40,7 +40,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     public function it_does_not_set_content_type_header(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('foo'));
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\Utils::streamFor()('foo'));
         $request->withHeader('Content-Type', null)->shouldNotBeCalled();
 
         $this->handleRequest($request, PluginStub::next(), function () {});
@@ -49,7 +49,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     public function it_does_not_set_content_type_header_if_already_one(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(true);
-        $request->getBody()->shouldNotBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('foo'));
+        $request->getBody()->shouldNotBeCalled()->willReturn(\GuzzleHttp\Psr7\Utils::streamFor()('foo'));
         $request->withHeader('Content-Type', null)->shouldNotBeCalled();
 
         $this->handleRequest($request, PluginStub::next(), function () {});
@@ -58,7 +58,7 @@ class ContentTypePluginSpec extends ObjectBehavior
     public function it_does_not_set_content_type_header_if_size_0_or_unknown(RequestInterface $request)
     {
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for());
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\Utils::streamFor());
         $request->withHeader('Content-Type', null)->shouldNotBeCalled();
 
         $this->handleRequest($request, PluginStub::next(), function () {});
@@ -71,7 +71,7 @@ class ContentTypePluginSpec extends ObjectBehavior
         ]);
 
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('<foo>bar</foo>'));
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\Utils::streamFor()('<foo>bar</foo>'));
         $request->withHeader('Content-Type', 'application/xml')->shouldBeCalled()->willReturn($request);
 
         $this->handleRequest($request, PluginStub::next(), function () {});
@@ -85,7 +85,7 @@ class ContentTypePluginSpec extends ObjectBehavior
         ]);
 
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('<foo>bar</foo>'));
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\Utils::streamFor()('<foo>bar</foo>'));
         $request->withHeader('Content-Type', 'application/xml')->shouldBeCalled()->willReturn($request);
 
         $this->handleRequest($request, PluginStub::next(), function () {});
@@ -99,7 +99,7 @@ class ContentTypePluginSpec extends ObjectBehavior
         ]);
 
         $request->hasHeader('Content-Type')->shouldBeCalled()->willReturn(false);
-        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\stream_for('<foo>bar</foo>'));
+        $request->getBody()->shouldBeCalled()->willReturn(\GuzzleHttp\Psr7\Utils::streamFor()('<foo>bar</foo>'));
         $request->withHeader('Content-Type', null)->shouldNotBeCalled();
 
         $this->handleRequest($request, PluginStub::next(), function () {});

--- a/tests/HttpMethodsClientTest.php
+++ b/tests/HttpMethodsClientTest.php
@@ -5,6 +5,7 @@ namespace Tests\Http\Client\Common;
 use Http\Client\Common\HttpMethodsClient;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -16,15 +17,9 @@ class HttpMethodsClientTest extends TestCase
     private const HEADER_VALUE = 'text/plain';
     private const BODY = 'body';
 
-    /**
-     * @var ClientInterface
-     */
-    private $httpClient;
+    private ClientInterface|MockObject $httpClient;
 
-    /**
-     * @var HttpMethodsClient
-     */
-    private $httpMethodsClient;
+    private HttpMethodsClient $httpMethodsClient;
 
     protected function setUp(): void
     {

--- a/tests/Plugin/RedirectPluginTest.php
+++ b/tests/Plugin/RedirectPluginTest.php
@@ -78,7 +78,7 @@ class RedirectPluginTest extends TestCase
         $this->assertSame('https://example.com/other', $response->getHeaderLine('uri'));
     }
 
-    public function provideRedirections(): array
+    public static function provideRedirections(): array
     {
         return [
             'no path on target' => ['https://example.com/path?query=value', 'https://example.com?query=value', 'https://example.com?query=value'],

--- a/tests/PluginChainTest.php
+++ b/tests/PluginChainTest.php
@@ -9,10 +9,13 @@ use Http\Client\Common\Plugin;
 use Http\Client\Common\PluginChain;
 use Http\Promise\Promise;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\RequestInterface;
 
 class PluginChainTest extends TestCase
 {
+    use ProphecyTrait;
+
     private function createPlugin(callable $func): Plugin
     {
         return new class($func) implements Plugin {

--- a/tests/PluginClientBuilderTest.php
+++ b/tests/PluginClientBuilderTest.php
@@ -10,9 +10,12 @@ use Http\Client\Common\PluginClientBuilder;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class PluginClientBuilderTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @dataProvider clientProvider */
     public function testPriority(string $client): void
     {
@@ -71,7 +74,7 @@ class PluginClientBuilderTest extends TestCase
         $this->assertSame(5, $options['max_restarts']);
     }
 
-    public function clientProvider(): iterable
+    public static function clientProvider(): iterable
     {
         yield 'sync\'d http client' => [HttpClient::class];
         yield 'async\'d http client' => [HttpAsyncClient::class];

--- a/tests/PluginClientTest.php
+++ b/tests/PluginClientTest.php
@@ -31,7 +31,7 @@ class PluginClientTest extends TestCase
         $this->assertInstanceOf($returnType, $result);
     }
 
-    public function clientAndMethodProvider()
+    public static function clientAndMethodProvider()
     {
         $syncClient = new class() implements ClientInterface {
             public function sendRequest(RequestInterface $request): ResponseInterface


### PR DESCRIPTION
https://github.com/php-http/client-common/issues/242

Just a quick view and open for disussion what to do next.
Needs rebasing after the other 2 PRs are merged.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] to Discuss
