### PR TITLE
Fix implicit nullable type to avoid PHP 8.4 warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,10 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Emulate PHP 8.3
+        run: composer config platform.php 8.3.999
+        if: matrix.php == '8.4'
+
       - name: Install PHP dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout code

--- a/src/HttpMethodsClient.php
+++ b/src/HttpMethodsClient.php
@@ -33,7 +33,7 @@ final class HttpMethodsClient implements HttpMethodsClientInterface
     /**
      * @param RequestFactory|RequestFactoryInterface $requestFactory
      */
-    public function __construct(ClientInterface $httpClient, $requestFactory, StreamFactoryInterface $streamFactory = null)
+    public function __construct(ClientInterface $httpClient, $requestFactory, ?StreamFactoryInterface $streamFactory = null)
     {
         if (!$requestFactory instanceof RequestFactory && !$requestFactory instanceof RequestFactoryInterface) {
             throw new \TypeError(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

This PR makes the implicit nullable type explicit. Using implicit nullable types has been deprecated, and will emit deprecation warnings in PHP 8.4


#### Why?

To avoid getting deprecation warnings in PHP 8.4



#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

