### PR TITLE
allow symfony 8 and test with php 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout code
@@ -25,10 +25,6 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v2
           coverage: none
-
-      - name: Emulate PHP 8.3
-        run: composer config platform.php 8.3.999
-        if: matrix.php == '8.4'
 
       - name: Install PHP dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
@@ -42,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.4', '8.2', '8.3']
+        php: ['7.1', '7.4', '8.2', '8.5']
 
     steps:
       - name: Checkout code
@@ -65,6 +61,7 @@ jobs:
     name: Symfony ${{ matrix.symfony }} LTS
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - symfony: '4.4.*'
@@ -73,8 +70,10 @@ jobs:
             php-version: '7.4'
           - symfony: '6.4.*'
             php-version: '8.2'
-          - symfony: '7.0.*'
+          - symfony: '7.4.*'
             php-version: '8.2'
+          - symfony: '8.*'
+            php-version: '8.5'
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2.7.3 - 2025-11-29
+
+- Allow installation with Symfony 8.
+- Run tests with PHP 8.5.
+
 ## 2.7.2 - 2024-09-24
 
 - Updated code to not raise warnings for nullable parameters in PHP 8.4.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "symfony/options-resolver": "~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/options-resolver": "~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

allow installation with symfony 8 components and run tests with php 8.5